### PR TITLE
disable golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,5 +10,4 @@ linters:
     - ineffassign
     - deadcode
     - typecheck
-    - golint
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,4 @@ linters:
     - deadcode
     - typecheck
     - gofmt
+    - revive

--- a/interfaces/handler/api.go
+++ b/interfaces/handler/api.go
@@ -30,8 +30,7 @@ func (c *Context) BindAndValidate(i interface{}) error {
 	if err := c.Bind(i); err != nil {
 		return err
 	}
-	if err := c.Validate(i); err != nil {
-		return err
-	}
-	return nil
+	err := c.Validate(i)
+
+	return err
 }

--- a/interfaces/repository/contest_impl.go
+++ b/interfaces/repository/contest_impl.go
@@ -111,10 +111,9 @@ func (repo *ContestRepository) UpdateContest(id uuid.UUID, changes map[string]in
 		if err := tx.Model(&old).Updates(changes).Error(); err != nil {
 			return err
 		}
-		if err := tx.Where(&model.Contest{ID: id}).First(&new).Error(); err != nil {
-			return err
-		}
-		return nil
+		err := tx.Where(&model.Contest{ID: id}).First(&new).Error()
+
+		return err
 	})
 	if err != nil {
 		return err
@@ -247,10 +246,9 @@ func (repo *ContestRepository) UpdateContestTeam(teamID uuid.UUID, changes map[s
 		if err := tx.Model(&old).Updates(changes).Error(); err != nil {
 			return err
 		}
-		if err := tx.Where(&model.ContestTeam{ID: teamID}).First(&new).Error(); err != nil {
-			return err
-		}
-		return nil
+		err := tx.Where(&model.ContestTeam{ID: teamID}).First(&new).Error()
+
+		return err
 	})
 	if err != nil {
 		return err

--- a/interfaces/repository/event_impl.go
+++ b/interfaces/repository/event_impl.go
@@ -87,10 +87,9 @@ func (repo *EventRepository) UpdateEvent(id uuid.UUID, arg *repository.UpdateEve
 		if err := tx.Model(&old).Updates(arg).Error(); err != nil {
 			return err
 		}
-		if err := tx.Where(&model.EventLevelRelation{ID: id}).First(&new).Error(); err != nil {
-			return err
-		}
-		return nil
+		err := tx.Where(&model.EventLevelRelation{ID: id}).First(&new).Error()
+
+		return err
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
warning出るので削除して良さそう？です
```fish
$ make golangci-lint                                                                                                                                                            
level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
```