### PR TITLE
:recycle: repository.GetAccountをservice.GetUserから呼び出す

### DIFF
--- a/interfaces/repository/user_impl.go
+++ b/interfaces/repository/user_impl.go
@@ -69,18 +69,13 @@ func (repo *UserRepository) GetUser(id uuid.UUID) (*domain.UserDetail, error) {
 		return nil, err
 	}
 
-	accounts, err := repo.GetAccounts(id)
-	if err != nil {
-		return nil, err
-	}
-
 	result := domain.UserDetail{
 		ID:       user.ID,
 		Name:     user.Name,
 		RealName: portalUser.RealName,
 		State:    traQUser.State,
 		Bio:      user.Description,
-		Accounts: accounts,
+		// Accounts: GetAccountsで取得
 	}
 
 	return &result, nil

--- a/usecases/service/user.go
+++ b/usecases/service/user.go
@@ -30,6 +30,11 @@ func (s *UserService) GetUser(ctx context.Context, id uuid.UUID) (*domain.UserDe
 	if err != nil {
 		return nil, err
 	}
+	accounts, err := s.repo.GetAccounts(id)
+	if err != nil {
+		return nil, err
+	}
+	user.Accounts = accounts
 	return user, nil
 }
 

--- a/usecases/service/user_test.go
+++ b/usecases/service/user_test.go
@@ -107,7 +107,14 @@ func TestUserService_GetUser(t *testing.T) {
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want *domain.UserDetail) {
 				want.ID = args.id
-				repo.EXPECT().GetUser(args.id).Return(want, nil)
+				repo.EXPECT().GetUser(args.id).Return(&domain.UserDetail{
+					ID:       want.ID,
+					Name:     want.Name,
+					RealName: want.RealName,
+					State:    want.State,
+					Bio:      want.Bio,
+				}, nil)
+				repo.EXPECT().GetAccounts(args.id).Return(want.Accounts, nil)
 			},
 			assertion: assert.NoError,
 		},


### PR DESCRIPTION
同階層から呼び出すのはテストしにくかったので変えましたがクリーンアーキテクチャ的にどうなのかあんまりわかってないです