### PR TITLE
:art: Remove subtests' prefix "Fail_"

### DIFF
--- a/usecases/service/project_test.go
+++ b/usecases/service/project_test.go
@@ -57,7 +57,7 @@ func TestProjectService_GetProjects(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "ErrInvalidDB",
 			args: args{ctx: context.Background()},
 			want: nil,
 			setup: func(repo *mock_repository.MockProjectRepository, portal *mock_repository.MockPortalRepository, args args, want []*domain.Project) {
@@ -136,7 +136,7 @@ func TestProjectService_GetProject(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_PortalForbidden",
+			name: "PortalForbidden",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -149,7 +149,7 @@ func TestProjectService_GetProject(t *testing.T) {
 			assertion: assert.Error,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -227,7 +227,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx: context.Background(),
 				args: &repository.CreateProjectArgs{
@@ -304,7 +304,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -388,7 +388,7 @@ func TestProjectService_GetProjectMembers(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_PortalForbidden",
+			name: "PortalForbidden",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -401,7 +401,7 @@ func TestProjectService_GetProjectMembers(t *testing.T) {
 			assertion: assert.Error,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -465,7 +465,7 @@ func TestProjectService_AddProjectMembers(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx:       context.Background(),
 				projectID: util.UUID(),
@@ -528,7 +528,7 @@ func TestProjectService_DeleteProjectMembers(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_ErrInvalidDB",
+			name: "InvalidDB",
 			args: args{
 				ctx:       context.Background(),
 				projectID: util.UUID(),

--- a/usecases/service/user_test.go
+++ b/usecases/service/user_test.go
@@ -43,7 +43,7 @@ func TestUserService_GetUsers(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Forbidden",
+			name: "Forbidden",
 			args: args{ctx: context.Background()},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.User) {
@@ -97,8 +97,8 @@ func TestUserService_GetUser(t *testing.T) {
 					Name:     util.AlphaNumeric(5),
 					RealName: util.AlphaNumeric(5),
 				},
-				State:    0,
-				Bio:      util.AlphaNumeric(10),
+				State: 0,
+				Bio:   util.AlphaNumeric(10),
 				Accounts: []*domain.Account{
 					{
 						ID:          util.UUID(),
@@ -114,7 +114,7 @@ func TestUserService_GetUser(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Forbidden",
+			name: "Forbidden",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -179,7 +179,7 @@ func TestUserService_Update(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Notfound",
+			name: "Notfound",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -352,7 +352,7 @@ func TestUserService_CreateAccount(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_EmptyID",
+			name: "EmptyID",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -369,7 +369,7 @@ func TestUserService_CreateAccount(t *testing.T) {
 			assertion: assert.Error,
 		},
 		{
-			name: "Fail_InvalidAccountType",
+			name: "InvalidAccountType",
 			args: args{
 				ctx: context.Background(),
 				id:  util.UUID(),
@@ -445,7 +445,7 @@ func TestUserService_EditAccount(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Notfound",
+			name: "Notfound",
 			args: args{
 				ctx:       context.Background(),
 				accountID: util.UUID(),
@@ -566,7 +566,7 @@ func TestUserService_GetUserProjects(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Notfound",
+			name: "Notfound",
 			args: args{
 				ctx:    context.Background(),
 				userID: util.UUID(),
@@ -631,7 +631,7 @@ func TestUserService_GetUserContests(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Notfound",
+			name: "Notfound",
 			args: args{
 				ctx:    context.Background(),
 				userID: util.UUID(),
@@ -696,7 +696,7 @@ func TestUserService_GetUserEvents(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "Fail_Notfound",
+			name: "Notfound",
 			args: args{
 				ctx:    context.Background(),
 				userID: util.UUID(),


### PR DESCRIPTION
テストのfailと紛らわしいので消しました

https://golang.org/src/testing/testing_test.go とか見ても命名規則バラバラなので何がいいかよくわかってないです