### PR TITLE
Fix repository.UpdateEvent

### DIFF
--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -104,8 +104,8 @@ func (handler *SQLHandler) Model(value interface{}) database.SQLHandler {
 	return &SQLHandler{conn: db}
 }
 
-func (handler *SQLHandler) Update(column string, values interface{}) database.SQLHandler {
-	db := handler.conn.Update(column, values)
+func (handler *SQLHandler) Update(column string, value interface{}) database.SQLHandler {
+	db := handler.conn.Update(column, value)
 	return &SQLHandler{conn: db}
 }
 

--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -104,6 +104,11 @@ func (handler *SQLHandler) Model(value interface{}) database.SQLHandler {
 	return &SQLHandler{conn: db}
 }
 
+func (handler *SQLHandler) Update(column string, values interface{}) database.SQLHandler {
+	db := handler.conn.Update(column, values)
+	return &SQLHandler{conn: db}
+}
+
 func (handler *SQLHandler) Updates(values interface{}) database.SQLHandler {
 	db := handler.conn.Updates(values)
 	return &SQLHandler{conn: db}

--- a/interfaces/database/mock_database/mock_sqlhandler.go
+++ b/interfaces/database/mock_database/mock_sqlhandler.go
@@ -61,8 +61,8 @@ func (handler *MockSQLHandler) Delete(value interface{}, where ...interface{}) d
 	return &MockSQLHandler{Conn: db}
 }
 
-func (handler *MockSQLHandler) Update(column string, values interface{}) database.SQLHandler {
-	db := handler.Conn.Update(column, values)
+func (handler *MockSQLHandler) Update(column string, value interface{}) database.SQLHandler {
+	db := handler.Conn.Update(column, value)
 	return &MockSQLHandler{Conn: db}
 }
 

--- a/interfaces/database/mock_database/mock_sqlhandler.go
+++ b/interfaces/database/mock_database/mock_sqlhandler.go
@@ -61,6 +61,11 @@ func (handler *MockSQLHandler) Delete(value interface{}, where ...interface{}) d
 	return &MockSQLHandler{Conn: db}
 }
 
+func (handler *MockSQLHandler) Update(column string, values interface{}) database.SQLHandler {
+	db := handler.Conn.Update(column, values)
+	return &MockSQLHandler{Conn: db}
+}
+
 func (handler *MockSQLHandler) Where(query interface{}, args ...interface{}) database.SQLHandler {
 	db := handler.Conn.Where(query, args...)
 	return &MockSQLHandler{Conn: db}

--- a/interfaces/database/sqlhandler.go
+++ b/interfaces/database/sqlhandler.go
@@ -7,6 +7,7 @@ type SQLHandler interface {
 	Delete(value interface{}, where ...interface{}) SQLHandler
 	Where(query interface{}, args ...interface{}) SQLHandler
 	Model(value interface{}) SQLHandler
+	Update(column string, value interface{}) SQLHandler
 	Updates(values interface{}) SQLHandler
 	Begin() SQLHandler
 	Commit() SQLHandler

--- a/interfaces/handler/event.go
+++ b/interfaces/handler/event.go
@@ -94,11 +94,11 @@ func (h *EventHandler) PatchEvent(_c echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	patchReq := repository.UpdateEventArg{
+	patchReq := repository.UpdateEventLevelArg{
 		Level: *req.EventLevel,
 	}
 
-	if err := h.srv.UpdateEvent(ctx, req.EventID, &patchReq); err != nil {
+	if err := h.srv.UpdateEventLevel(ctx, req.EventID, &patchReq); err != nil {
 		return convertError(err)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/interfaces/repository/event_impl.go
+++ b/interfaces/repository/event_impl.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
@@ -90,12 +89,6 @@ func (repo *EventRepository) UpdateEventLevel(id uuid.UUID, arg *repository.Upda
 
 		if err := tx.Model(&model.EventLevelRelation{ID: id}).Update("level", arg.Level).Error(); err != nil {
 			return err
-		}
-
-		if elv, err := repo.getEventLevelByID(id); err != nil {
-			return err
-		} else if elv.Level != arg.Level {
-			return fmt.Errorf("updated level was expected %d, but got %d", elv.Level, arg.Level)
 		}
 
 		return nil

--- a/interfaces/repository/event_impl.go
+++ b/interfaces/repository/event_impl.go
@@ -80,7 +80,7 @@ func (repo *EventRepository) GetEvent(id uuid.UUID) (*domain.EventDetail, error)
 	return result, nil
 }
 
-func (repo *EventRepository) UpdateEvent(id uuid.UUID, arg *repository.UpdateEventArg) error {
+func (repo *EventRepository) UpdateEventLevel(id uuid.UUID, arg *repository.UpdateEventLevelArg) error {
 	err := repo.h.Transaction(func(tx database.SQLHandler) error {
 		if elv, err := repo.getEventLevelByID(id); err != nil {
 			return err

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -176,12 +176,6 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
 					WithArgs(args.arg.Level, args.id).
 					WillReturnResult(sqlmock.NewResult(1, 1))
-				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
-					WithArgs(args.id).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "level"}).
-							AddRow(args.id, args.arg.Level),
-					)
 				h.Mock.ExpectCommit()
 			},
 			assertion: assert.NoError,
@@ -245,63 +239,6 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
 					WithArgs(args.arg.Level, args.id).
 					WillReturnError(errUnexpected)
-				h.Mock.ExpectRollback()
-			},
-			assertion: assert.Error,
-		},
-		{
-			name: "ConfirmingError",
-			args: args{
-				id: sampleUUID,
-				arg: &repository.UpdateEventLevelArg{
-					Level: domain.EventLevelPublic,
-				},
-			},
-			setup: func(f mockEventRepositoryFields, args args) {
-				h := f.h.(*mock_database.MockSQLHandler)
-				h.Mock.ExpectBegin()
-				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
-					WithArgs(args.id).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "level"}).
-							AddRow(args.id, domain.EventLevelAnonymous),
-					)
-				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
-					WithArgs(args.arg.Level, args.id).
-					WillReturnResult(sqlmock.NewResult(1, 1))
-				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
-					WithArgs(args.id).
-					WillReturnError(errUnexpected)
-				h.Mock.ExpectRollback()
-			},
-			assertion: assert.Error,
-		},
-		{
-			name: "InconsistentLevel",
-			args: args{
-				id: sampleUUID,
-				arg: &repository.UpdateEventLevelArg{
-					Level: domain.EventLevelPublic,
-				},
-			},
-			setup: func(f mockEventRepositoryFields, args args) {
-				h := f.h.(*mock_database.MockSQLHandler)
-				h.Mock.ExpectBegin()
-				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
-					WithArgs(args.id).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "level"}).
-							AddRow(args.id, domain.EventLevelAnonymous),
-					)
-				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
-					WithArgs(args.arg.Level, args.id).
-					WillReturnResult(sqlmock.NewResult(1, 1))
-				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
-					WithArgs(args.id).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "level"}).
-							AddRow(args.id, domain.EventLevelAnonymous), // not equal to args.arg.Level
-					)
 				h.Mock.ExpectRollback()
 			},
 			assertion: assert.Error,

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -144,7 +144,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 	}
 }
 
-func TestEventRepository_UpdateEvent(t *testing.T) {
+func TestEventRepository_UpdateEventLevel(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		id  uuid.UUID

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -148,7 +148,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		id  uuid.UUID
-		arg *repository.UpdateEventArg
+		arg *repository.UpdateEventLevelArg
 	}
 	tests := []struct {
 		name      string
@@ -160,7 +160,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "Success",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -190,7 +190,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "LevelNotFound",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -208,7 +208,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "DoNotUpdate",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -229,7 +229,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "UpdateError",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -253,7 +253,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "ConfirmingError",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -280,7 +280,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			name: "InconsistentLevel",
 			args: args{
 				id: sampleUUID,
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelPublic,
 				},
 			},
@@ -316,7 +316,7 @@ func TestEventRepository_UpdateEvent(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewEventRepository(f.h, f.api)
 			// Assertion
-			tt.assertion(t, repo.UpdateEvent(tt.args.id, tt.args.arg))
+			tt.assertion(t, repo.UpdateEventLevel(tt.args.id, tt.args.arg))
 		})
 	}
 }

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -142,3 +142,180 @@ func TestEventRepository_GetEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestEventRepository_UpdateEvent(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		id  uuid.UUID
+		arg *repository.UpdateEventArg
+	}
+	tests := []struct {
+		name      string
+		args      args
+		setup     func(f mockEventRepositoryFields, args args)
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Success",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelAnonymous),
+					)
+				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
+					WithArgs(args.arg.Level, args.id).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, args.arg.Level),
+					)
+				h.Mock.ExpectCommit()
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "LevelNotFound",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnError(repository.ErrNotFound)
+				h.Mock.ExpectRollback()
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "DoNotUpdate",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelPublic), // equal to args.arg.Level
+					)
+				h.Mock.ExpectCommit()
+			},
+			assertion: assert.NoError,
+		},
+		{
+			name: "UpdateError",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelAnonymous),
+					)
+				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
+					WithArgs(args.arg.Level, args.id).
+					WillReturnError(errUnexpected)
+				h.Mock.ExpectRollback()
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "ConfirmingError",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelAnonymous),
+					)
+				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
+					WithArgs(args.arg.Level, args.id).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnError(errUnexpected)
+				h.Mock.ExpectRollback()
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "InconsistentLevel",
+			args: args{
+				id: sampleUUID,
+				arg: &repository.UpdateEventArg{
+					Level: domain.EventLevelPublic,
+				},
+			},
+			setup: func(f mockEventRepositoryFields, args args) {
+				h := f.h.(*mock_database.MockSQLHandler)
+				h.Mock.ExpectBegin()
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelAnonymous),
+					)
+				h.Mock.ExpectExec(regexp.QuoteMeta("UPDATE `event_level_relations` SET `level`=? WHERE `id` = ?")).
+					WithArgs(args.arg.Level, args.id).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
+					WithArgs(args.id).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "level"}).
+							AddRow(args.id, domain.EventLevelAnonymous), // not equal to args.arg.Level
+					)
+				h.Mock.ExpectRollback()
+			},
+			assertion: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Setup mock
+			f := newMockEventRepositoryFields()
+			tt.setup(f, tt.args)
+			repo := NewEventRepository(f.h, f.api)
+			// Assertion
+			tt.assertion(t, repo.UpdateEvent(tt.args.id, tt.args.arg))
+		})
+	}
+}

--- a/interfaces/repository/model/event.go
+++ b/interfaces/repository/model/event.go
@@ -7,6 +7,6 @@ import (
 )
 
 type EventLevelRelation struct {
-	ID    uuid.UUID          `gorm:"type:char(36);not null;primaryKey"`
-	Level *domain.EventLevel `gorm:"type:tinyint unsigned;not null;default:0"`
+	ID    uuid.UUID         `gorm:"type:char(36);not null;primaryKey"`
+	Level domain.EventLevel `gorm:"type:tinyint unsigned;not null;default:0"`
 }

--- a/usecases/repository/event_repository.go
+++ b/usecases/repository/event_repository.go
@@ -7,13 +7,13 @@ import (
 	"github.com/traPtitech/traPortfolio/domain"
 )
 
-type UpdateEventArg struct {
+type UpdateEventLevelArg struct {
 	Level domain.EventLevel
 }
 
 type EventRepository interface {
 	GetEvents() ([]*domain.Event, error)
 	GetEvent(id uuid.UUID) (*domain.EventDetail, error)
-	UpdateEvent(id uuid.UUID, arg *UpdateEventArg) error
+	UpdateEventLevel(id uuid.UUID, arg *UpdateEventLevelArg) error
 	GetUserEvents(userID uuid.UUID) ([]*domain.Event, error)
 }

--- a/usecases/repository/mock_repository/mock_event_repository.go
+++ b/usecases/repository/mock_repository/mock_event_repository.go
@@ -81,16 +81,16 @@ func (mr *MockEventRepositoryMockRecorder) GetUserEvents(userID interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserEvents", reflect.TypeOf((*MockEventRepository)(nil).GetUserEvents), userID)
 }
 
-// UpdateEvent mocks base method.
-func (m *MockEventRepository) UpdateEvent(id uuid.UUID, arg *repository.UpdateEventArg) error {
+// UpdateEventLevel mocks base method.
+func (m *MockEventRepository) UpdateEventLevel(id uuid.UUID, arg *repository.UpdateEventLevelArg) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEvent", id, arg)
+	ret := m.ctrl.Call(m, "UpdateEventLevel", id, arg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateEvent indicates an expected call of UpdateEvent.
-func (mr *MockEventRepositoryMockRecorder) UpdateEvent(id, arg interface{}) *gomock.Call {
+// UpdateEventLevel indicates an expected call of UpdateEventLevel.
+func (mr *MockEventRepositoryMockRecorder) UpdateEventLevel(id, arg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEvent", reflect.TypeOf((*MockEventRepository)(nil).UpdateEvent), id, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEventLevel", reflect.TypeOf((*MockEventRepository)(nil).UpdateEventLevel), id, arg)
 }

--- a/usecases/service/event.go
+++ b/usecases/service/event.go
@@ -47,6 +47,6 @@ func (s *EventService) GetEventByID(ctx context.Context, id uuid.UUID) (*domain.
 	return event, nil
 }
 
-func (s *EventService) UpdateEvent(ctx context.Context, id uuid.UUID, arg *repository.UpdateEventArg) error {
-	return s.event.UpdateEvent(id, arg)
+func (s *EventService) UpdateEventLevel(ctx context.Context, id uuid.UUID, arg *repository.UpdateEventLevelArg) error {
+	return s.event.UpdateEventLevel(id, arg)
 }

--- a/usecases/service/event_test.go
+++ b/usecases/service/event_test.go
@@ -209,7 +209,7 @@ func TestEventService_UpdateEvent(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  uuid.UUID
-		arg *repository.UpdateEventArg
+		arg *repository.UpdateEventLevelArg
 	}
 	tests := []struct {
 		name      string
@@ -223,13 +223,13 @@ func TestEventService_UpdateEvent(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				id:  random.UUID(),
-				arg: &repository.UpdateEventArg{
+				arg: &repository.UpdateEventLevelArg{
 					Level: domain.EventLevelAnonymous,
 				},
 			},
 			setup: func(f fields, args args) {
 				e := f.event.(*mock_repository.MockEventRepository)
-				e.EXPECT().UpdateEvent(args.id, args.arg).Return(nil)
+				e.EXPECT().UpdateEventLevel(args.id, args.arg).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -247,7 +247,7 @@ func TestEventService_UpdateEvent(t *testing.T) {
 			tt.setup(tt.fields, tt.args)
 			s := NewEventService(tt.fields.event, tt.fields.user)
 			// Assertion
-			tt.assertion(t, s.UpdateEvent(tt.args.ctx, tt.args.id, tt.args.arg))
+			tt.assertion(t, s.UpdateEventLevel(tt.args.ctx, tt.args.id, tt.args.arg))
 		})
 	}
 }


### PR DESCRIPTION
Closes #142 

- [Update](https://gorm.io/ja_JP/docs/update.html#%E5%8D%98%E4%B8%80%E3%81%AE%E3%82%AB%E3%83%A9%E3%83%A0%E3%82%92%E6%9B%B4%E6%96%B0%E3%81%99%E3%82%8B)を使ってlevelカラムだけを変更
  - `(repository.UpdateEventArg).Level`がゼロ値でも問題なくなったのでポインタ型やめた
- 存在確認した時にすでに変更したいのと同じLevelがDBに入っていたらUpdateせずに終わるようにした
- エラーハンドリングをちょっと追加した
- テスト書いた

好みかもですが`UpdateEvent`より`UpdateEventLevel`のほうがいいかなと思いましたが迷ったので変更してないです