### PR TITLE
mockEventRepositoryFields等のfieldをinterfaceからstructにする

### DIFF
--- a/interfaces/repository/event_impl.go
+++ b/interfaces/repository/event_impl.go
@@ -12,16 +12,16 @@ import (
 )
 
 type EventRepository struct {
-	h   database.SQLHandler
-	api external.KnoqAPI
+	h    database.SQLHandler
+	knoq external.KnoqAPI
 }
 
 func NewEventRepository(sql database.SQLHandler, knoq external.KnoqAPI) repository.EventRepository {
-	return &EventRepository{h: sql, api: knoq}
+	return &EventRepository{h: sql, knoq: knoq}
 }
 
 func (repo *EventRepository) GetEvents() ([]*domain.Event, error) {
-	events, err := repo.api.GetAll()
+	events, err := repo.knoq.GetAll()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -41,7 +41,7 @@ func (repo *EventRepository) GetEvents() ([]*domain.Event, error) {
 }
 
 func (repo *EventRepository) GetEvent(id uuid.UUID) (*domain.EventDetail, error) {
-	er, err := repo.api.GetByID(id)
+	er, err := repo.knoq.GetByID(id)
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -101,7 +101,7 @@ func (repo *EventRepository) UpdateEventLevel(id uuid.UUID, arg *repository.Upda
 }
 
 func (repo *EventRepository) GetUserEvents(userID uuid.UUID) ([]*domain.Event, error) {
-	events, err := repo.api.GetByUserID(userID)
+	events, err := repo.knoq.GetByUserID(userID)
 	if err != nil {
 		return nil, convertError(err)
 	}

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -19,14 +19,14 @@ import (
 )
 
 type mockEventRepositoryFields struct {
-	h   *mock_database.MockSQLHandler
-	api *mock_external.MockKnoqAPI
+	h    *mock_database.MockSQLHandler
+	knoq *mock_external.MockKnoqAPI
 }
 
 func newMockEventRepositoryFields(ctrl *gomock.Controller) mockEventRepositoryFields {
 	return mockEventRepositoryFields{
-		h:   mock_database.NewMockSQLHandler(),
-		api: mock_external.NewMockKnoqAPI(ctrl),
+		h:    mock_database.NewMockSQLHandler(),
+		knoq: mock_external.NewMockKnoqAPI(ctrl),
 	}
 }
 
@@ -55,7 +55,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 				},
 			},
 			setup: func(f mockEventRepositoryFields, want []*domain.Event) {
-				f.api.EXPECT().GetAll().Return(makeKnoqEvents(want), nil)
+				f.knoq.EXPECT().GetAll().Return(makeKnoqEvents(want), nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -63,7 +63,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 			name: "KnoqError",
 			want: nil,
 			setup: func(f mockEventRepositoryFields, want []*domain.Event) {
-				f.api.EXPECT().GetAll().Return(nil, errUnexpected)
+				f.knoq.EXPECT().GetAll().Return(nil, errUnexpected)
 			},
 			assertion: assert.Error,
 		},
@@ -76,7 +76,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			f := newMockEventRepositoryFields(ctrl)
 			tt.setup(f, tt.want)
-			repo := impl.NewEventRepository(f.h, f.api)
+			repo := impl.NewEventRepository(f.h, f.knoq)
 			// Assertion
 			got, err := repo.GetEvents()
 			tt.assertion(t, err)
@@ -117,7 +117,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 				RoomID:      random.UUID(),
 			},
 			setup: func(f mockEventRepositoryFields, args args, want *domain.EventDetail) {
-				f.api.EXPECT().GetByID(args.id).Return(makeKnoqEvent(want), nil)
+				f.knoq.EXPECT().GetByID(args.id).Return(makeKnoqEvent(want), nil)
 				f.h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
 					WithArgs(args.id).
 					WillReturnRows(
@@ -134,7 +134,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 			},
 			want: nil,
 			setup: func(f mockEventRepositoryFields, args args, want *domain.EventDetail) {
-				f.api.EXPECT().GetByID(args.id).Return(nil, repository.ErrNotFound)
+				f.knoq.EXPECT().GetByID(args.id).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -158,7 +158,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 				RoomID:      random.UUID(),
 			},
 			setup: func(f mockEventRepositoryFields, args args, want *domain.EventDetail) {
-				f.api.EXPECT().GetByID(args.id).Return(makeKnoqEvent(want), nil)
+				f.knoq.EXPECT().GetByID(args.id).Return(makeKnoqEvent(want), nil)
 				f.h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
 					WithArgs(args.id).
 					WillReturnError(gorm.ErrRecordNotFound)
@@ -186,7 +186,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 					GroupID:     random.UUID(),
 					RoomID:      random.UUID(),
 				}
-				f.api.EXPECT().GetByID(args.id).Return(makeKnoqEvent(&ed), nil)
+				f.knoq.EXPECT().GetByID(args.id).Return(makeKnoqEvent(&ed), nil)
 				f.h.Mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `event_level_relations` WHERE `event_level_relations`.`id` = ? ORDER BY `event_level_relations`.`id` LIMIT 1")).
 					WithArgs(args.id).
 					WillReturnError(errUnexpected)
@@ -202,7 +202,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			f := newMockEventRepositoryFields(ctrl)
 			tt.setup(f, tt.args, tt.want)
-			repo := impl.NewEventRepository(f.h, f.api)
+			repo := impl.NewEventRepository(f.h, f.knoq)
 			// Assertion
 			got, err := repo.GetEvent(tt.args.id)
 			tt.assertion(t, err)
@@ -315,7 +315,7 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			f := newMockEventRepositoryFields(ctrl)
 			tt.setup(f, tt.args)
-			repo := impl.NewEventRepository(f.h, f.api)
+			repo := impl.NewEventRepository(f.h, f.knoq)
 			// Assertion
 			tt.assertion(t, repo.UpdateEventLevel(tt.args.id, tt.args.arg))
 		})
@@ -354,7 +354,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 				},
 			},
 			setup: func(f mockEventRepositoryFields, args args, want []*domain.Event) {
-				f.api.EXPECT().GetByUserID(args.userID).Return(makeKnoqEvents(want), nil)
+				f.knoq.EXPECT().GetByUserID(args.userID).Return(makeKnoqEvents(want), nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -365,7 +365,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 			},
 			want: nil,
 			setup: func(f mockEventRepositoryFields, args args, want []*domain.Event) {
-				f.api.EXPECT().GetByUserID(args.userID).Return(nil, errUnexpected)
+				f.knoq.EXPECT().GetByUserID(args.userID).Return(nil, errUnexpected)
 			},
 			assertion: assert.Error,
 		},
@@ -378,7 +378,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			f := newMockEventRepositoryFields(ctrl)
 			tt.setup(f, tt.args, tt.want)
-			repo := impl.NewEventRepository(f.h, f.api)
+			repo := impl.NewEventRepository(f.h, f.knoq)
 			// Assertion
 			got, err := repo.GetUserEvents(tt.args.userID)
 			tt.assertion(t, err)

--- a/interfaces/repository/user_impl.go
+++ b/interfaces/repository/user_impl.go
@@ -12,22 +12,22 @@ import (
 )
 
 type UserRepository struct {
-	database.SQLHandler
+	h      database.SQLHandler
 	portal external.PortalAPI
 	traQ   external.TraQAPI
 }
 
-func NewUserRepository(sql database.SQLHandler, portalAPI external.PortalAPI, traQAPI external.TraQAPI) repository.UserRepository {
+func NewUserRepository(h database.SQLHandler, portalAPI external.PortalAPI, traQAPI external.TraQAPI) repository.UserRepository {
 	return &UserRepository{
-		SQLHandler: sql,
-		portal:     portalAPI,
-		traQ:       traQAPI,
+		h:      h,
+		portal: portalAPI,
+		traQ:   traQAPI,
 	}
 }
 
 func (repo *UserRepository) GetUsers() ([]*domain.User, error) {
 	users := make([]*model.User, 0)
-	err := repo.Find(&users).Error()
+	err := repo.h.Find(&users).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -57,7 +57,7 @@ func (repo *UserRepository) GetUsers() ([]*domain.User, error) {
 
 func (repo *UserRepository) GetUser(id uuid.UUID) (*domain.UserDetail, error) {
 	user := new(model.User)
-	err := repo.
+	err := repo.h.
 		Preload("Accounts").
 		Where(&model.User{ID: id}).
 		First(user).
@@ -112,7 +112,7 @@ func (repo *UserRepository) CreateUser(args repository.CreateUserArgs) (*domain.
 		Name:        args.Name,
 	}
 
-	err = repo.Create(&user).Error()
+	err = repo.h.Create(&user).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -132,7 +132,7 @@ func (repo *UserRepository) CreateUser(args repository.CreateUserArgs) (*domain.
 
 func (repo *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
 	accounts := make([]*model.Account, 0)
-	err := repo.
+	err := repo.h.
 		Where(&model.Account{UserID: userID}).
 		Find(&accounts).
 		Error()
@@ -153,7 +153,7 @@ func (repo *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, er
 
 func (repo *UserRepository) GetAccount(userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
 	account := &model.Account{}
-	err := repo.
+	err := repo.h.
 		Where(&model.Account{ID: accountID, UserID: userID}).
 		First(account).
 		Error()
@@ -183,9 +183,9 @@ func (repo *UserRepository) UpdateUser(id uuid.UUID, args *repository.UpdateUser
 		return nil
 	}
 
-	err := repo.Transaction(func(tx database.SQLHandler) error {
+	err := repo.h.Transaction(func(tx database.SQLHandler) error {
 		user := new(model.User)
-		err := repo.
+		err := repo.h.
 			Where(&model.User{ID: id}).
 			First(user).
 			Error()
@@ -193,7 +193,7 @@ func (repo *UserRepository) UpdateUser(id uuid.UUID, args *repository.UpdateUser
 			return convertError(err)
 		}
 
-		err = repo.Model(user).Updates(changes).Error()
+		err = repo.h.Model(user).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -215,13 +215,13 @@ func (repo *UserRepository) CreateAccount(id uuid.UUID, args *repository.CreateA
 		UserID: id,
 		Check:  args.PrPermitted,
 	}
-	err := repo.Create(&account).Error()
+	err := repo.h.Create(&account).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
 
 	ver := new(model.Account)
-	if err := repo.
+	if err := repo.h.
 		Where(&model.Account{ID: account.ID}).
 		First(ver).
 		Error(); err != nil {
@@ -256,9 +256,9 @@ func (repo *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID,
 		return nil
 	}
 
-	err := repo.Transaction(func(tx database.SQLHandler) error {
+	err := repo.h.Transaction(func(tx database.SQLHandler) error {
 		account := new(model.Account)
-		err := repo.
+		err := repo.h.
 			Where(&model.Account{ID: accountID, UserID: userID}).
 			First(account).
 			Error()
@@ -266,7 +266,7 @@ func (repo *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID,
 			return convertError(err)
 		}
 
-		err = repo.Model(account).Updates(changes).Error()
+		err = repo.h.Model(account).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -276,7 +276,7 @@ func (repo *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID,
 }
 
 func (repo *UserRepository) DeleteAccount(accountID uuid.UUID, userID uuid.UUID) error {
-	if err := repo.
+	if err := repo.h.
 		Where(&model.Account{ID: accountID, UserID: userID}).
 		Delete(&domain.Account{}).
 		Error(); err != nil {
@@ -288,7 +288,7 @@ func (repo *UserRepository) DeleteAccount(accountID uuid.UUID, userID uuid.UUID)
 
 func (repo *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, error) {
 	projects := make([]*model.ProjectMember, 0)
-	err := repo.
+	err := repo.h.
 		Preload("Project").
 		Where(&model.ProjectMember{UserID: userID}).
 		Find(&projects).
@@ -312,7 +312,7 @@ func (repo *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject
 
 func (repo *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.GroupUser, error) {
 	groups := make([]*model.GroupUserBelonging, 0)
-	err := repo.
+	err := repo.h.
 		Preload("Group").
 		Where(&model.GroupUserBelonging{UserID: userID}).
 		Find(&groups).
@@ -344,7 +344,7 @@ func (repo *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.Group
 
 func (repo *UserRepository) GetContests(userID uuid.UUID) ([]*domain.UserContest, error) {
 	contests := make([]*model.ContestTeamUserBelonging, 0)
-	err := repo.
+	err := repo.h.
 		Preload("ContestTeam.Contest").
 		Where(&model.ContestTeamUserBelonging{UserID: userID}).
 		Find(&contests).

--- a/usecases/repository/mock_repository/mock_user_repository.go
+++ b/usecases/repository/mock_repository/mock_user_repository.go
@@ -52,18 +52,18 @@ func (mr *MockUserRepositoryMockRecorder) CreateAccount(id, args interface{}) *g
 }
 
 // CreateUser mocks base method.
-func (m *MockUserRepository) CreateUser(arg repository.CreateUserArgs) (*domain.UserDetail, error) {
+func (m *MockUserRepository) CreateUser(args repository.CreateUserArgs) (*domain.UserDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUser", arg)
+	ret := m.ctrl.Call(m, "CreateUser", args)
 	ret0, _ := ret[0].(*domain.UserDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockUserRepositoryMockRecorder) CreateUser(arg interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) CreateUser(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), args)
 }
 
 // DeleteAccount mocks base method.


### PR DESCRIPTION
- :recycle: Change mockXXXRepositoryFields's fields type
- :recycle: rename api to knoq
