### PR TITLE
:recycle: 環境変数の読み込みをconfig.goに移行

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,30 +3,29 @@ package main
 import (
 	"flag"
 	"log"
-	"os"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/traPortfolio/infrastructure"
 	"github.com/traPtitech/traPortfolio/interfaces/handler"
+	"github.com/traPtitech/traPortfolio/util/config"
 )
 
 func main() {
 	migrate := flag.Bool("migrate", false, "migration mode or not")
 	flag.Parse()
 	if *migrate {
-		conf := sqlConf()
-		_, err := infrastructure.NewSQLHandler(&conf)
+		s := config.SQLConf()
+		_, err := infrastructure.NewSQLHandler(&s)
 		if err != nil {
 			log.Fatal(err)
 		}
 		log.Println("finished")
 	} else {
-		isDevelopment := os.Getenv("APP_ENV") == "development"
-		s := sqlConf()
-		t := traQConf(isDevelopment)
-		p := portalConf(isDevelopment)
-		k := knoQConf(isDevelopment)
+		isDevelopment := config.IsDevelopment()
+		s := config.SQLConf()
+		t := config.TraqConf(isDevelopment)
+		p := config.PortalConf(isDevelopment)
+		k := config.KnoqConf(isDevelopment)
 
 		api, err := infrastructure.InjectAPIServer(&s, &t, &p, &k)
 		if err != nil {
@@ -36,59 +35,7 @@ func main() {
 		e := echo.New()
 		handler.Setup(e, api)
 
-		port := os.Getenv("PORT")
-		if port == "" {
-			port = ":1323"
-		}
 		// Start server
-		e.Logger.Fatal(e.Start(port))
+		e.Logger.Fatal(e.Start(config.Port()))
 	}
-}
-
-func sqlConf() infrastructure.SQLConfig {
-	user := os.Getenv("DB_USER")
-	if user == "" {
-		user = "root"
-	}
-	password := os.Getenv("DB_PASSWORD")
-	if password == "" {
-		password = "password"
-	}
-
-	host := os.Getenv("DB_HOST")
-	if host == "" {
-		host = "mysql"
-	}
-
-	port, err := strconv.Atoi(os.Getenv("DB_PORT"))
-	if err != nil {
-		port = 3306
-	}
-
-	dbname := os.Getenv("DB_DATABASE")
-	if dbname == "" {
-		dbname = "portfolio"
-	}
-
-	return infrastructure.NewSQLConfig(user, password, host, dbname, port)
-}
-
-func traQConf(isDevelopment bool) infrastructure.TraQConfig {
-	traQCookie := os.Getenv("TRAQ_COOKIE")
-	traQAPIEndpoint := os.Getenv("TRAQ_API_ENDPOINT")
-
-	return infrastructure.NewTraQConfig(traQCookie, traQAPIEndpoint, isDevelopment)
-}
-
-func knoQConf(isDevelopment bool) infrastructure.KnoQConfig {
-	knoQCookie := os.Getenv("KNOQ_COOKIE")
-	knoQAPIEndpoint := os.Getenv("KNOQ_API_ENDPOINT")
-
-	return infrastructure.NewKnoqConfig(knoQCookie, knoQAPIEndpoint, isDevelopment)
-}
-
-func portalConf(isDevelopment bool) infrastructure.PortalConfig {
-	portalCookie := os.Getenv("PORTAL_COOKIE")
-	portalAPIEndpoint := os.Getenv("PORTAL_API_ENDPOINT")
-	return infrastructure.NewPortalConfig(portalCookie, portalAPIEndpoint, isDevelopment)
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/traPtitech/traPortfolio/infrastructure"
+)
+
+const (
+	envAppEnv            = "APP_ENV"
+	envPort              = "PORT"
+	envDBUser            = "DB_USER"
+	envDBPass            = "DB_PASSWORD"
+	envDBHost            = "DB_HOST"
+	envDBName            = "DB_DATABASE"
+	envDBPort            = "DB_PORT"
+	envTraqCookie        = "TRAQ_COOKIE"
+	envTraqAPIEndpoint   = "TRAQ_API_ENDPOINT"
+	envKnoqCookie        = "KNOQ_COOKIE"
+	envKnoqAPIEndpoint   = "KNOQ_API_ENDPOINT"
+	envPortalCookie      = "PORTAL_COOKIE"
+	envPortalAPIEndpoint = "PORTAL_API_ENDPOINT"
+)
+
+func IsDevelopment() bool {
+	return os.Getenv(envAppEnv) == "development"
+}
+
+func Port() string {
+	return fmt.Sprintf(":%d", getNumEnvOrDefault(envPort, 1323))
+}
+
+func SQLConf() infrastructure.SQLConfig {
+	user := getEnvOrDefault(envDBUser, "root")
+	pass := getEnvOrDefault(envDBPass, "password")
+	host := getEnvOrDefault(envDBHost, "mysql")
+	dbname := getEnvOrDefault(envDBName, "portfolio")
+	port := getNumEnvOrDefault(envDBPort, 3306)
+
+	return infrastructure.NewSQLConfig(user, pass, host, dbname, port)
+}
+
+func TraqConf(isDevelopment bool) infrastructure.TraQConfig {
+	traQCookie := os.Getenv(envTraqCookie)
+	traQAPIEndpoint := os.Getenv(envTraqAPIEndpoint)
+
+	return infrastructure.NewTraQConfig(traQCookie, traQAPIEndpoint, isDevelopment)
+}
+
+func KnoqConf(isDevelopment bool) infrastructure.KnoQConfig {
+	knoQCookie := os.Getenv(envKnoqCookie)
+	knoQAPIEndpoint := os.Getenv(envKnoqAPIEndpoint)
+
+	return infrastructure.NewKnoqConfig(knoQCookie, knoQAPIEndpoint, isDevelopment)
+}
+
+func PortalConf(isDevelopment bool) infrastructure.PortalConfig {
+	portalCookie := os.Getenv(envPortalCookie)
+	portalAPIEndpoint := os.Getenv(envPortalAPIEndpoint)
+
+	return infrastructure.NewPortalConfig(portalCookie, portalAPIEndpoint, isDevelopment)
+}
+
+func getEnvOrDefault(env string, def string) string {
+	s := os.Getenv(env)
+	if len(s) == 0 {
+		return def
+	}
+
+	return s
+}
+
+func getNumEnvOrDefault(env string, def int) int {
+	i, err := strconv.Atoi(os.Getenv(env))
+	if err != nil {
+		return def
+	}
+
+	return i
+}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -22,6 +22,12 @@ const (
 	envKnoqAPIEndpoint   = "KNOQ_API_ENDPOINT"
 	envPortalCookie      = "PORTAL_COOKIE"
 	envPortalAPIEndpoint = "PORTAL_API_ENDPOINT"
+	defaultPort          = 1323
+	defaultDBUser        = "root"
+	defaultDBPass        = "password"
+	defaultDBHost        = "mysql"
+	defaultDBName        = "portfolio"
+	defaultDBPort        = 3306
 )
 
 func IsDevelopment() bool {
@@ -29,15 +35,15 @@ func IsDevelopment() bool {
 }
 
 func Port() string {
-	return fmt.Sprintf(":%d", getNumEnvOrDefault(envPort, 1323))
+	return fmt.Sprintf(":%d", getNumEnvOrDefault(envPort, defaultPort))
 }
 
 func SQLConf() infrastructure.SQLConfig {
-	user := getEnvOrDefault(envDBUser, "root")
-	pass := getEnvOrDefault(envDBPass, "password")
-	host := getEnvOrDefault(envDBHost, "mysql")
-	dbname := getEnvOrDefault(envDBName, "portfolio")
-	port := getNumEnvOrDefault(envDBPort, 3306)
+	user := getEnvOrDefault(envDBUser, defaultDBUser)
+	pass := getEnvOrDefault(envDBPass, defaultDBPass)
+	host := getEnvOrDefault(envDBHost, defaultDBHost)
+	dbname := getEnvOrDefault(envDBName, defaultDBName)
+	port := getNumEnvOrDefault(envDBPort, defaultDBPort)
 
 	return infrastructure.NewSQLConfig(user, pass, host, dbname, port)
 }


### PR DESCRIPTION
https://github.com/traPtitech/traPortfolio/blob/2c6d93ea40e68a72d5f16aeb8a181e891e4a8ba8/integration_tests/handler/main_test.go#L21-L27 などで環境変数の読み込みが分散するのが気になったので移行しました
