### PR TITLE
user.goの結合テストの続き

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -3,6 +3,6 @@ insertMockData: false
 db:
   user: 'root'
   pass: 'password'
-  host: 'mysql'
+  host: 'localhost'
   name: 'portfolio'
-  port: 3306
+  port: 3307

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -3,6 +3,6 @@ insertMockData: false
 db:
   user: 'root'
   pass: 'password'
-  host: 'localhost'
+  host: 'mysql'
   name: 'portfolio'
-  port: 3307
+  port: 3306

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -656,30 +656,49 @@ func TestGetUserContests(t *testing.T) {
 	}
 }
 
-// // GetUserGroups GET /users/:userID/groups
-// func TestGetUserGroups(t *testing.T) {
-// 	t.Parallel()
-// 	tests := map[string]struct {
-// 		statusCode int
-// 		userID     uuid.UUID
-// 		want       interface{}
-// 	}{
-// 		// TODO: Add cases
-// 	}
+// GetUserGroups GET /users/:userID/groups
+func TestGetUserGroups(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		statusCode int
+		userID     uuid.UUID
+		want       interface{}
+	}{
+		"200": {
+			http.StatusOK,
+			mockdata.HMockUsers[0].Id,
+			mockdata.HMockUserGroups,
+		},
+		"200 no groups with existing userID": {
+			http.StatusOK,
+			mockdata.HMockUsers[1].Id,
+			[]handler.Group{},
+		},
+		"200 no groups with non-existing userID": {
+			http.StatusOK,
+			random.UUID(),
+			[]handler.Group{},
+		},
+		"400 invalid userID": {
+			http.StatusBadRequest,
+			uuid.Nil,
+			handler.ConvertError(t, repository.ErrValidate),
+		},
+	}
 
-// 	e := echo.New()
-// 	conf := testutils.GetConfigWithDBName("user_handler_get_user_groups")
-// 	api, err := testutils.SetupRoutes(t, e, conf)
-// 	assert.NoError(t, err)
-// 	for name, tt := range tests {
-// 		tt := tt
-// 		t.Run(name, func(t *testing.T) {
-//			t.Parallel()
-// 			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserGroups, tt.userID), nil)
-// 			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
-// 		})
-// 	}
-// }
+	e := echo.New()
+	conf := testutils.GetConfigWithDBName("user_handler_get_user_groups")
+	api, err := testutils.SetupRoutes(t, e, conf)
+	assert.NoError(t, err)
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserGroups, tt.userID), nil)
+			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
+		})
+	}
+}
 
 // // GetUserEvents GET /users/:userID/events
 // func TestGetUserEvents(t *testing.T) {

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -612,30 +612,49 @@ func TestGetUserProjects(t *testing.T) {
 	}
 }
 
-// // GetUserContests GET /users/:userID/contests
-// func TestGetUserContests(t *testing.T) {
-// 	t.Parallel()
-// 	tests := map[string]struct {
-// 		statusCode int
-// 		userID     uuid.UUID
-// 		want       interface{}
-// 	}{
-// 		// TODO: Add cases
-// 	}
+// GetUserContests GET /users/:userID/contests
+func TestGetUserContests(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		statusCode int
+		userID     uuid.UUID
+		want       interface{}
+	}{
+		"200": {
+			http.StatusOK,
+			mockdata.HMockUsers[0].Id,
+			mockdata.HMockUserContests,
+		},
+		"200 no contests with existing userID": {
+			http.StatusOK,
+			mockdata.HMockUsers[1].Id,
+			[]handler.Contest{},
+		},
+		"200 no contests with non-existing userID": {
+			http.StatusOK,
+			random.UUID(),
+			[]handler.Contest{},
+		},
+		"400 invalid userID": {
+			http.StatusBadRequest,
+			uuid.Nil,
+			handler.ConvertError(t, repository.ErrValidate),
+		},
+	}
 
-// 	e := echo.New()
-// 	conf := testutils.GetConfigWithDBName("user_handler_get_user_contests")
-// 	api, err := testutils.SetupRoutes(t, e, conf)
-// 	assert.NoError(t, err)
-// 	for name, tt := range tests {
-// 		tt := tt
-// 		t.Run(name, func(t *testing.T) {
-//    	t.Parallel()
-// 			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserContests, tt.userID), nil)
-// 			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
-// 		})
-// 	}
-// }
+	e := echo.New()
+	conf := testutils.GetConfigWithDBName("user_handler_get_user_contests")
+	api, err := testutils.SetupRoutes(t, e, conf)
+	assert.NoError(t, err)
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserContests, tt.userID), nil)
+			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
+		})
+	}
+}
 
 // // GetUserGroups GET /users/:userID/groups
 // func TestGetUserGroups(t *testing.T) {

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -249,7 +249,7 @@ func TestGetUserAccount(t *testing.T) {
 			http.StatusOK,
 			mockdata.HMockUsers[0].Id,
 			mockdata.HMockUserAccounts[0].Id,
-			mockdata.HMockUserAccounts,
+			mockdata.HMockUserAccounts[0],
 		},
 		"400 invalid userID": {
 			http.StatusBadRequest,

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -205,7 +205,12 @@ func TestGetUserAccounts(t *testing.T) {
 			mockdata.HMockUsers[0].Id,
 			mockdata.HMockUserAccounts,
 		},
-		"200 no accounts": {
+		"200 no accounts with existing userID": {
+			http.StatusOK,
+			mockdata.HMockUsers[1].Id,
+			[]handler.Account{},
+		},
+		"200 no accounts with not-existing userID": {
 			http.StatusOK,
 			random.UUID(),
 			[]handler.Account{},

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -700,27 +700,48 @@ func TestGetUserGroups(t *testing.T) {
 	}
 }
 
-// // GetUserEvents GET /users/:userID/events
-// func TestGetUserEvents(t *testing.T) {
-// 	t.Parallel()
-// 	tests := map[string]struct {
-// 		statusCode int
-// 		userID     uuid.UUID
-// 		want       interface{}
-// 	}{
-// 		// TODO: Add cases
-// 	}
+// GetUserEvents GET /users/:userID/events
+func TestGetUserEvents(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		statusCode int
+		userID     uuid.UUID
+		want       interface{}
+	}{
+		"200": {
+			http.StatusOK,
+			mockdata.HMockUsers[0].Id,
+			mockdata.HMockUserEvents,
+		},
+		"200 no events with existing userID": {
+			http.StatusOK,
+			mockdata.HMockUsers[1].Id,
+			[]handler.Event{
+				mockdata.HMockUserEvents[1],
+			},
+		},
+		"200 no events with non-existing userID": {
+			http.StatusOK,
+			random.UUID(),
+			[]handler.Event{},
+		},
+		"400 invalid userID": {
+			http.StatusBadRequest,
+			uuid.Nil,
+			handler.ConvertError(t, repository.ErrValidate),
+		},
+	}
 
-// 	e := echo.New()
-// 	conf := testutils.GetConfigWithDBName("user_handler_get_user_events")
-// 	api, err := testutils.SetupRoutes(t, e, conf)
-// 	assert.NoError(t, err)
-// 	for name, tt := range tests {
-// 		tt := tt
-// 		t.Run(name, func(t *testing.T) {
-//			t.Parallel()
-// 			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserEvents, tt.userID), nil)
-// 			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
-// 		})
-// 	}
-// }
+	e := echo.New()
+	conf := testutils.GetConfigWithDBName("user_handler_get_user_events")
+	api, err := testutils.SetupRoutes(t, e, conf)
+	assert.NoError(t, err)
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserEvents, tt.userID), nil)
+			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
+		})
+	}
+}

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -203,9 +203,7 @@ func TestGetUserAccounts(t *testing.T) {
 		"200": {
 			http.StatusOK,
 			mockdata.HMockUsers[0].Id,
-			[]handler.Account{
-				mockdata.HMockUserAccount,
-			},
+			mockdata.HMockUserAccounts,
 		},
 		"200 no accounts": {
 			http.StatusOK,
@@ -245,13 +243,13 @@ func TestGetUserAccount(t *testing.T) {
 		"200": {
 			http.StatusOK,
 			mockdata.HMockUsers[0].Id,
-			mockdata.HMockUserAccount.Id,
-			mockdata.HMockUserAccount,
+			mockdata.HMockUserAccounts[0].Id,
+			mockdata.HMockUserAccounts,
 		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.HMockUserAccount.Id,
+			mockdata.HMockUserAccounts[0].Id,
 			handler.ConvertError(t, repository.ErrValidate),
 		},
 		"400 invalid accountID": {
@@ -263,7 +261,7 @@ func TestGetUserAccount(t *testing.T) {
 		"404 userID not found": {
 			http.StatusNotFound,
 			random.UUID(),
-			mockdata.HMockUserAccount.Id,
+			mockdata.HMockUserAccounts[0].Id,
 			handler.ConvertError(t, repository.ErrNotFound),
 		},
 		"404 accountID not found": {
@@ -415,7 +413,7 @@ func TestEditUserRequestAccount(t *testing.T) {
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.HMockUserAccount.Id,
+			mockdata.HMockUserAccounts[0].Id,
 			handler.EditUserAccountJSONRequestBody{},
 			handler.ConvertError(t, repository.ErrValidate),
 		},

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -563,30 +563,49 @@ func TestDeleteUserAccount(t *testing.T) {
 	}
 }
 
-// // GetUserProjects GET /users/:userID/projects
-// func TestGetUserProjects(t *testing.T) {
-// 	t.Parallel()
-// 	tests := map[string]struct {
-// 		statusCode int
-// 		userID     uuid.UUID
-// 		want       interface{}
-// 	}{
-// 		// TODO: Add cases
-// 	}
+// GetUserProjects GET /users/:userID/projects
+func TestGetUserProjects(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		statusCode int
+		userID     uuid.UUID
+		want       interface{}
+	}{
+		"200": {
+			http.StatusOK,
+			mockdata.HMockUsers[0].Id,
+			mockdata.HMockUserProjects,
+		},
+		"200 no projects with existing userID": {
+			http.StatusOK,
+			mockdata.HMockUsers[1].Id,
+			[]handler.Project{},
+		},
+		"200 no projects with non-existing userID": {
+			http.StatusOK,
+			random.UUID(),
+			[]handler.Project{},
+		},
+		"400 invalid userID": {
+			http.StatusBadRequest,
+			uuid.Nil,
+			handler.ConvertError(t, repository.ErrValidate),
+		},
+	}
 
-// 	e := echo.New()
-// 	conf := testutils.GetConfigWithDBName("user_handler_get_user_projects")
-// 	api, err := testutils.SetupRoutes(t, e, conf)
-// 	assert.NoError(t, err)
-// 	for name, tt := range tests {
-// 		tt := tt
-// 		t.Run(name, func(t *testing.T) {
-// 			t.Parallel()
-// 			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserProjects, tt.userID), nil)
-// 			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
-// 		})
-// 	}
-// }
+	e := echo.New()
+	conf := testutils.GetConfigWithDBName("user_handler_get_user_projects")
+	api, err := testutils.SetupRoutes(t, e, conf)
+	assert.NoError(t, err)
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := testutils.DoRequest(t, e, http.MethodGet, e.URL(api.User.GetUserProjects, tt.userID), nil)
+			testutils.AssertResponse(t, tt.statusCode, tt.want, res)
+		})
+	}
+}
 
 // // GetUserContests GET /users/:userID/contests
 // func TestGetUserContests(t *testing.T) {

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -210,15 +210,15 @@ func TestGetUserAccounts(t *testing.T) {
 			mockdata.HMockUsers[1].Id,
 			[]handler.Account{},
 		},
-		"200 no accounts with not-existing userID": {
-			http.StatusOK,
-			random.UUID(),
-			[]handler.Account{},
-		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
 			handler.ConvertError(t, repository.ErrValidate),
+		},
+		"404 no accounts with not-existing userID": {
+			http.StatusNotFound,
+			random.UUID(),
+			handler.ConvertError(t, repository.ErrNotFound),
 		},
 	}
 
@@ -586,15 +586,15 @@ func TestGetUserProjects(t *testing.T) {
 			mockdata.HMockUsers[1].Id,
 			[]handler.Project{},
 		},
-		"200 no projects with non-existing userID": {
-			http.StatusOK,
-			random.UUID(),
-			[]handler.Project{},
-		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
 			handler.ConvertError(t, repository.ErrValidate),
+		},
+		"404 no accounts with not-existing userID": {
+			http.StatusNotFound,
+			random.UUID(),
+			handler.ConvertError(t, repository.ErrNotFound),
 		},
 	}
 
@@ -630,15 +630,15 @@ func TestGetUserContests(t *testing.T) {
 			mockdata.HMockUsers[1].Id,
 			[]handler.Contest{},
 		},
-		"200 no contests with non-existing userID": {
-			http.StatusOK,
-			random.UUID(),
-			[]handler.Contest{},
-		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
 			handler.ConvertError(t, repository.ErrValidate),
+		},
+		"404 no accounts with not-existing userID": {
+			http.StatusNotFound,
+			random.UUID(),
+			handler.ConvertError(t, repository.ErrNotFound),
 		},
 	}
 
@@ -674,15 +674,15 @@ func TestGetUserGroups(t *testing.T) {
 			mockdata.HMockUsers[1].Id,
 			[]handler.Group{},
 		},
-		"200 no groups with non-existing userID": {
-			http.StatusOK,
-			random.UUID(),
-			[]handler.Group{},
-		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
 			handler.ConvertError(t, repository.ErrValidate),
+		},
+		"404 no accounts with not-existing userID": {
+			http.StatusNotFound,
+			random.UUID(),
+			handler.ConvertError(t, repository.ErrNotFound),
 		},
 	}
 

--- a/interfaces/external/mock_external_e2e/mock_knoq.go
+++ b/interfaces/external/mock_external_e2e/mock_knoq.go
@@ -29,5 +29,17 @@ func (m *MockKnoqAPI) GetByEventID(eventID uuid.UUID) (*external.EventResponse, 
 }
 
 func (m *MockKnoqAPI) GetByUserID(userID uuid.UUID) ([]*external.EventResponse, error) {
-	return mockdata.MockKnoqEvents, nil
+	events := make([]*external.EventResponse, 0, len(mockdata.MockKnoqEvents))
+
+	// TODO: adminsではなくattendeesを取得して判定する？
+	for _, v := range mockdata.MockKnoqEvents {
+		for _, admin := range v.Admins {
+			if admin == userID {
+				events = append(events, v)
+				break
+			}
+		}
+	}
+
+	return events, nil
 }

--- a/interfaces/repository/user_impl.go
+++ b/interfaces/repository/user_impl.go
@@ -216,8 +216,16 @@ func (repo *UserRepository) UpdateUser(userID uuid.UUID, args *repository.Update
 }
 
 func (repo *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
-	accounts := make([]*model.Account, 0)
 	err := repo.h.
+		Where(&model.User{ID: userID}).
+		First(&model.User{}).
+		Error()
+	if err != nil {
+		return nil, convertError(err)
+	}
+
+	accounts := make([]*model.Account, 0)
+	err = repo.h.
 		Where(&model.Account{UserID: userID}).
 		Find(&accounts).
 		Error()
@@ -353,8 +361,16 @@ func (repo *UserRepository) DeleteAccount(userID uuid.UUID, accountID uuid.UUID)
 }
 
 func (repo *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, error) {
-	projects := make([]*model.ProjectMember, 0)
 	err := repo.h.
+		Where(&model.User{ID: userID}).
+		First(&model.User{}).
+		Error()
+	if err != nil {
+		return nil, convertError(err)
+	}
+
+	projects := make([]*model.ProjectMember, 0)
+	err = repo.h.
 		Preload("Project").
 		Where(&model.ProjectMember{UserID: userID}).
 		Find(&projects).
@@ -377,8 +393,16 @@ func (repo *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject
 }
 
 func (repo *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.GroupUser, error) {
-	groups := make([]*model.GroupUserBelonging, 0)
 	err := repo.h.
+		Where(&model.User{ID: userID}).
+		First(&model.User{}).
+		Error()
+	if err != nil {
+		return nil, convertError(err)
+	}
+
+	groups := make([]*model.GroupUserBelonging, 0)
+	err = repo.h.
 		Preload("Group").
 		Where(&model.GroupUserBelonging{UserID: userID}).
 		Find(&groups).
@@ -409,8 +433,16 @@ func (repo *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.Group
 }
 
 func (repo *UserRepository) GetContests(userID uuid.UUID) ([]*domain.UserContest, error) {
-	contests := make([]*model.ContestTeamUserBelonging, 0)
 	err := repo.h.
+		Where(&model.User{ID: userID}).
+		First(&model.User{}).
+		Error()
+	if err != nil {
+		return nil, convertError(err)
+	}
+
+	contests := make([]*model.ContestTeamUserBelonging, 0)
+	err = repo.h.
 		Preload("ContestTeam.Contest").
 		Where(&model.ContestTeamUserBelonging{UserID: userID}).
 		Find(&contests).

--- a/interfaces/repository/user_impl_test.go
+++ b/interfaces/repository/user_impl_test.go
@@ -599,6 +599,18 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 			},
 			assertion: assert.Error,
 		},
+		{
+			name: "User not found",
+			args: args{userID: random.UUID()},
+			want: nil,
+			setup: func(f mockUserRepositoryFields, args args, want []*domain.Account) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnError(gorm.ErrRecordNotFound)
+			},
+			assertion: assert.Error,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -1156,6 +1168,18 @@ func TestUserRepository_GetProjects(t *testing.T) {
 			},
 			assertion: assert.Error,
 		},
+		{
+			name: "User not found",
+			args: args{userID: random.UUID()},
+			want: nil,
+			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserProject) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnError(gorm.ErrRecordNotFound)
+			},
+			assertion: assert.Error,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -1234,6 +1258,18 @@ func TestUserRepository_GetGroupsByUserID(t *testing.T) {
 					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `group_user_belongings` WHERE `group_user_belongings`.`user_id` = ?")).
 					WithArgs(args.userID).
 					WillReturnError(errUnexpected)
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "User not found",
+			args: args{userID: random.UUID()},
+			want: nil,
+			setup: func(f mockUserRepositoryFields, args args, want []*domain.GroupUser) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnError(gorm.ErrRecordNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -1325,6 +1361,18 @@ func TestUserRepository_GetContests(t *testing.T) {
 				f.h.Mock.ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `contest_team_user_belongings` WHERE `contest_team_user_belongings`.`user_id` = ?")).
 					WithArgs(args.userID).
 					WillReturnError(errUnexpected)
+			},
+			assertion: assert.Error,
+		},
+		{
+			name: "User not found",
+			args: args{userID: random.UUID()},
+			want: nil,
+			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserContest) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnError(gorm.ErrRecordNotFound)
 			},
 			assertion: assert.Error,
 		},

--- a/interfaces/repository/user_impl_test.go
+++ b/interfaces/repository/user_impl_test.go
@@ -568,6 +568,10 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 				},
 			},
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.Account) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				rows := sqlmock.NewRows([]string{"id", "user_id", "type", "check"})
 				for _, v := range want {
 					rows.AddRow(v.ID, args.userID, v.Type, v.PrPermitted)
@@ -584,6 +588,10 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 			args: args{random.UUID()},
 			want: nil,
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.Account) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				f.h.Mock.
 					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `accounts` WHERE `accounts`.`user_id` = ?")).
 					WithArgs(args.userID).
@@ -1107,6 +1115,10 @@ func TestUserRepository_GetProjects(t *testing.T) {
 				},
 			},
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserProject) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				rows := sqlmock.NewRows([]string{"id", "project_id", "user_id", "since_year", "since_semester", "until_year", "until_semester"})
 				for _, v := range want {
 					ud := v.UserDuration
@@ -1133,6 +1145,10 @@ func TestUserRepository_GetProjects(t *testing.T) {
 			args: args{userID: random.UUID()},
 			want: nil,
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserProject) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				f.h.Mock.
 					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `project_members` WHERE `project_members`.`user_id` = ?")).
 					WithArgs(args.userID).
@@ -1181,6 +1197,10 @@ func TestUserRepository_GetGroupsByUserID(t *testing.T) {
 				},
 			},
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.GroupUser) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				rows := sqlmock.NewRows([]string{"id", "group_id", "user_id", "since_year", "since_semester", "until_year", "until_semester"})
 				for _, v := range want {
 					d := v.Duration
@@ -1206,6 +1226,10 @@ func TestUserRepository_GetGroupsByUserID(t *testing.T) {
 			args: args{userID: random.UUID()},
 			want: nil,
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.GroupUser) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				f.h.Mock.
 					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `group_user_belongings` WHERE `group_user_belongings`.`user_id` = ?")).
 					WithArgs(args.userID).
@@ -1255,6 +1279,10 @@ func TestUserRepository_GetContests(t *testing.T) {
 				},
 			},
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserContest) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				rows := sqlmock.NewRows([]string{"team_id"})
 				for _, v := range want {
 					rows.AddRow(v.ID)
@@ -1290,6 +1318,10 @@ func TestUserRepository_GetContests(t *testing.T) {
 			args: args{userID: random.UUID()},
 			want: nil,
 			setup: func(f mockUserRepositoryFields, args args, want []*domain.UserContest) {
+				f.h.Mock.
+					ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(args.userID).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(args.userID))
 				f.h.Mock.ExpectQuery(makeSQLQueryRegexp("SELECT * FROM `contest_team_user_belongings` WHERE `contest_team_user_belongings`.`user_id` = ?")).
 					WithArgs(args.userID).
 					WillReturnError(errUnexpected)

--- a/util/mockdata/handler.go
+++ b/util/mockdata/handler.go
@@ -55,7 +55,7 @@ func CloneHandlerMockContestTeam() handler.ContestTeamDetail {
 
 	return handler.ContestTeamDetail{
 		Description: mContestTeam.Description,
-		Id:          mContestTeam.ContestID,
+		Id:          mContestTeam.ID,
 		Link:        mContestTeam.Link,
 		Members: []handler.User{
 			{

--- a/util/mockdata/handler.go
+++ b/util/mockdata/handler.go
@@ -186,7 +186,7 @@ func CloneHandlerMockProjectMembers() []handler.ProjectMember {
 		{
 			Duration: handler.YearWithSemesterDuration{
 				Since: handler.YearWithSemester{
-					Year:     mProjectMember.Project.SinceYear,
+					Year:     mProjectMember.SinceYear,
 					Semester: handler.Semester(mProjectMember.SinceSemester),
 				},
 				Until: &handler.YearWithSemester{

--- a/util/mockdata/handler.go
+++ b/util/mockdata/handler.go
@@ -16,6 +16,7 @@ var (
 	HMockUsers          = CloneHandlerMockUsers()
 	HMockUserDetails    = CloneHandlerMockUserDetails()
 	HMockUserAccounts   = CloneHandlerMockUserAccounts()
+	HMockUserEvents     = CloneHandlerMockUserEvents()
 	HMockUserContests   = CloneHandlerMockUserContests()
 	HMockUserGroups     = CloneHandlerMockUserGroups()
 	HMockUserProjects   = CloneHandlerMockUserProjects()
@@ -258,6 +259,23 @@ func CloneHandlerMockUserAccounts() []handler.Account {
 			Url:         mAccount.URL,
 		},
 	}
+}
+
+func CloneHandlerMockUserEvents() []handler.Event {
+	var (
+		hEventDetails = CloneHandlerMockEvents()
+		mUserEvents   = make([]handler.Event, len(hEventDetails))
+	)
+
+	for i, e := range hEventDetails {
+		mUserEvents[i] = handler.Event{
+			Duration: e.Duration,
+			Id:       e.Id,
+			Name:     e.Name,
+		}
+	}
+
+	return mUserEvents
 }
 
 func CloneHandlerMockUserContests() []handler.ContestTeamWithContestName {

--- a/util/mockdata/handler.go
+++ b/util/mockdata/handler.go
@@ -15,10 +15,10 @@ var (
 	HMockProjectMembers = CloneHandlerMockProjectMembers()
 	HMockUsers          = CloneHandlerMockUsers()
 	HMockUserDetails    = CloneHandlerMockUserDetails()
-	HMockUserAccount    = CloneHandlerMockUserAccount()
-	HMockUserContest    = CloneHandlerMockUserContest()
-	HMockUserGroup      = CloneHandlerMockUserGroup()
-	HMockUserProject    = CloneHandlerMockUserProject()
+	HMockUserAccounts   = CloneHandlerMockUserAccounts()
+	HMockUserContests   = CloneHandlerMockUserContests()
+	HMockUserGroups     = CloneHandlerMockUserGroups()
+	HMockUserProjects   = CloneHandlerMockUserProjects()
 )
 
 func CloneHandlerMockContest() handler.ContestDetail {
@@ -224,7 +224,7 @@ func CloneHandlerMockUserDetails() []handler.UserDetail {
 		mUsers      = CloneMockUsers()
 		portalUsers = CloneMockPortalUsers()
 		traqUsers   = CloneMockTraQUsers()
-		hAccount    = CloneHandlerMockUserAccount()
+		hAccounts   = CloneHandlerMockUserAccounts()
 		hUsers      = make([]handler.UserDetail, len(mUsers))
 	)
 
@@ -238,65 +238,79 @@ func CloneHandlerMockUserDetails() []handler.UserDetail {
 			State:    handler.UserAccountState(traqUsers[i].User.State),
 		}
 
-		if i == 0 {
-			hUsers[i].Accounts = append(hUsers[i].Accounts, hAccount)
+		if mu.ID == userID1.uuid() {
+			hUsers[i].Accounts = hAccounts
 		}
 	}
 
 	return hUsers
 }
 
-func CloneHandlerMockUserAccount() handler.Account {
+func CloneHandlerMockUserAccounts() []handler.Account {
 	var mAccount = CloneMockAccount()
 
-	return handler.Account{
-		DisplayName: mAccount.Name,
-		Id:          mAccount.ID,
-		PrPermitted: handler.PrPermitted(mAccount.Check),
-		Type:        handler.AccountType(mAccount.Type),
-		Url:         mAccount.URL,
+	return []handler.Account{
+		{
+			DisplayName: mAccount.Name,
+			Id:          mAccount.ID,
+			PrPermitted: handler.PrPermitted(mAccount.Check),
+			Type:        handler.AccountType(mAccount.Type),
+			Url:         mAccount.URL,
+		},
 	}
 }
 
-func CloneHandlerMockUserContest() handler.ContestTeamWithContestName {
+func CloneHandlerMockUserContests() []handler.ContestTeamWithContestName {
 	var (
 		hContest     = CloneHandlerMockContest()
 		hContestTeam = CloneHandlerMockContestTeam()
 	)
 
-	return handler.ContestTeamWithContestName{
-		ContestName: hContest.Name,
-		Id:          hContestTeam.Id,
-		Name:        hContestTeam.Name,
-		Result:      hContestTeam.Result,
+	return []handler.ContestTeamWithContestName{
+		{
+			ContestName: hContest.Name,
+			Id:          hContestTeam.Id,
+			Name:        hContestTeam.Name,
+			Result:      hContestTeam.Result,
+		},
 	}
 }
 
-func CloneHandlerMockUserGroup() handler.UserGroup {
+func CloneHandlerMockUserGroups() []handler.UserGroup {
 	var (
 		hGroup        = CloneHandlerMockGroup()
 		hGroupMembers = CloneHandlerMockGroupMembers()
+		hUserGroups   = make([]handler.UserGroup, len(hGroupMembers))
 	)
 
-	return handler.UserGroup{
-		Duration: hGroupMembers[0].Duration,
-		Id:       hGroup.Id,
-		Name:     hGroup.Name,
+	for i, gm := range hGroupMembers {
+		hUserGroups[i] = handler.UserGroup{
+			Duration: gm.Duration,
+			Id:       hGroup.Id,
+			Name:     hGroup.Name,
+		}
 	}
+
+	return hUserGroups
 }
 
-func CloneHandlerMockUserProject() handler.UserProject {
+func CloneHandlerMockUserProjects() []handler.UserProject {
 	var (
 		hProject        = CloneHandlerMockProject()
 		hProjectMembers = CloneHandlerMockProjectMembers()
+		hUserProjects   = make([]handler.UserProject, len(hProjectMembers))
 	)
 
-	return handler.UserProject{
-		Duration:     hProjectMembers[0].Duration,
-		Id:           hProject.Id,
-		Name:         hProject.Name,
-		UserDuration: hProjectMembers[0].Duration,
+	for i, pm := range hProjectMembers {
+		hUserProjects[i] = handler.UserProject{
+			Duration:     hProject.Duration,
+			Id:           hProject.Id,
+			Name:         hProject.Name,
+			UserDuration: pm.Duration,
+		}
 	}
+
+	return hUserProjects
 }
 
 func getUser(userID uuid.UUID) handler.User {


### PR DESCRIPTION
- :boom: CloneHandlerMockUserXXX -> CloneHandlerMockUserXXXs
- :bug: Fix assignment
- :white_check_mark: Test GetUserProjects
- :white_check_mark: Add case to TestGetUserAccounts
- :bug: Fix id assignment
- :white_check_mark: Test GetUserContests
- :white_check_mark: Test GetUserGroups
- :sparkles: Define CloneHandlerMockUserEvents & fix GetByUserID process
- :white_check_mark: Test GetUserEvents
