### PR TITLE
結合テストの UUID の表示を変更した

### DIFF
--- a/integration_tests/handler/contest_test.go
+++ b/integration_tests/handler/contest_test.go
@@ -50,7 +50,7 @@ func GetContest(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockContests[0].Id,
+			mockdata.ContestID(),
 			mockdata.HMockContests[0],
 		},
 		"400 invalid userID": {

--- a/integration_tests/handler/contest_test.go
+++ b/integration_tests/handler/contest_test.go
@@ -50,7 +50,7 @@ func GetContest(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.ContestID(),
+			mockdata.ContestID1(),
 			mockdata.HMockContests[0],
 		},
 		"400 invalid userID": {

--- a/integration_tests/handler/event_test.go
+++ b/integration_tests/handler/event_test.go
@@ -53,7 +53,7 @@ func TestEventHandler_GetEvent(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockEventDetails[0].Id,
+			mockdata.KnoqEventGroupID1(),
 			mockdata.HMockEventDetails[0],
 		},
 		"400 invalid userID": {
@@ -97,7 +97,7 @@ func TestEventHandler_EditEvent(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockEventDetails[0].Id,
+			mockdata.KnoqEventGroupID1(),
 			handler.EditEventRequest{
 				EventLevel: &eventLevel,
 			},
@@ -105,7 +105,7 @@ func TestEventHandler_EditEvent(t *testing.T) {
 		},
 		"204 without change": {
 			http.StatusNoContent,
-			mockdata.HMockEventDetails[1].Id,
+			mockdata.KnoqEventGroupID2(),
 			handler.EditEventRequest{},
 			nil,
 		},

--- a/integration_tests/handler/event_test.go
+++ b/integration_tests/handler/event_test.go
@@ -53,7 +53,7 @@ func TestEventHandler_GetEvent(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.KnoqEventGroupID1(),
+			mockdata.KnoqEventID1(),
 			mockdata.HMockEventDetails[0],
 		},
 		"400 invalid userID": {
@@ -97,7 +97,7 @@ func TestEventHandler_EditEvent(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.KnoqEventGroupID1(),
+			mockdata.KnoqEventID1(),
 			handler.EditEventRequest{
 				EventLevel: &eventLevel,
 			},

--- a/integration_tests/handler/event_test.go
+++ b/integration_tests/handler/event_test.go
@@ -105,7 +105,7 @@ func TestEventHandler_EditEvent(t *testing.T) {
 		},
 		"204 without change": {
 			http.StatusNoContent,
-			mockdata.KnoqEventGroupID2(),
+			mockdata.KnoqEventID2(),
 			handler.EditEventRequest{},
 			nil,
 		},

--- a/integration_tests/handler/group_test.go
+++ b/integration_tests/handler/group_test.go
@@ -25,7 +25,7 @@ func TestGetGroups(t *testing.T) {
 			http.StatusOK,
 			[]handler.Group{
 				{
-					Id:   mockdata.GroupID(),
+					Id:   mockdata.GroupID1(),
 					Name: mockdata.HMockGroups[0].Name,
 				},
 			},
@@ -58,7 +58,7 @@ func TestGetGroup(t *testing.T) {
 	}{
 		"200": {
 			statusCode: http.StatusOK,
-			groupID:    mockdata.GroupID(),
+			groupID:    mockdata.GroupID1(),
 			want:       mockdata.HMockGroups[0],
 		},
 		"400 invalid userID": {

--- a/integration_tests/handler/group_test.go
+++ b/integration_tests/handler/group_test.go
@@ -25,7 +25,7 @@ func TestGetGroups(t *testing.T) {
 			http.StatusOK,
 			[]handler.Group{
 				{
-					Id:   mockdata.HMockGroups[0].Id,
+					Id:   mockdata.GroupID(),
 					Name: mockdata.HMockGroups[0].Name,
 				},
 			},
@@ -58,7 +58,7 @@ func TestGetGroup(t *testing.T) {
 	}{
 		"200": {
 			statusCode: http.StatusOK,
-			groupID:    mockdata.HMockGroups[0].Id,
+			groupID:    mockdata.GroupID(),
 			want:       mockdata.HMockGroups[0],
 		},
 		"400 invalid userID": {

--- a/integration_tests/handler/project_test.go
+++ b/integration_tests/handler/project_test.go
@@ -51,7 +51,7 @@ func TestGetProject(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockProjectDetails[0].Id,
+			mockdata.ProjectID1(),
 			mockdata.HMockProjectDetails[0],
 		},
 		"400 invalid projectID": {
@@ -186,7 +186,7 @@ func TestEditProject(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockProjects[0].Id,
+			mockdata.ProjectID1(),
 			handler.EditProjectJSONRequestBody{
 				Name:        &name,
 				Link:        &link,
@@ -197,7 +197,7 @@ func TestEditProject(t *testing.T) {
 		},
 		"204 without changes": {
 			http.StatusNoContent,
-			mockdata.HMockProjects[0].Id,
+			mockdata.ProjectID1(),
 			handler.EditProjectJSONRequestBody{},
 			nil,
 		},
@@ -250,7 +250,7 @@ func TestGetProjectMembers(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockProjects[0].Id,
+			mockdata.ProjectID1(),
 			[]handler.ProjectMember{
 				mockdata.HMockProjectMembers[0],
 				mockdata.HMockProjectMembers[1],
@@ -258,7 +258,7 @@ func TestGetProjectMembers(t *testing.T) {
 		},
 		"200 no members with existing projectID": {
 			http.StatusOK,
-			mockdata.HMockProjects[2].Id,
+			mockdata.ProjectID3(),
 			[]handler.ProjectMember{},
 		},
 		"400 invalid projectID": {
@@ -285,9 +285,9 @@ func TestGetProjectMembers(t *testing.T) {
 // AddProjectMembers POST /projects/:projectID/members
 func TestAddProjectMembers(t *testing.T) {
 	var (
-		userID1   = mockdata.HMockUsers[0].Id
+		userID1   = mockdata.UserID1()
 		duration1 = handler.ConvertDuration(random.Duration())
-		userID2   = mockdata.HMockUsers[1].Id
+		userID2   = mockdata.UserID2()
 		duration2 = handler.ConvertDuration(random.Duration())
 	)
 
@@ -300,7 +300,7 @@ func TestAddProjectMembers(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockProjects[0].Id,
+			mockdata.ProjectID1(),
 			handler.AddProjectMembersJSONRequestBody{
 				Members: []handler.MemberIDWithYearWithSemesterDuration{
 					{
@@ -351,7 +351,7 @@ func TestDeleteProjectMembers(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockProjects[0].Id,
+			mockdata.ProjectID1(),
 			handler.DeleteProjectMembersJSONRequestBody{
 				Members: []uuid.UUID{userID1},
 			},

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -92,7 +92,7 @@ func TestGetUser(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUserDetails[0].Id,
+			mockdata.UserID1(),
 			mockdata.HMockUserDetails[0],
 		},
 		"400 invalid userID": {
@@ -137,7 +137,7 @@ func TestUpdateUser(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			handler.EditUserRequest{
 				Bio:   &bio,
 				Check: &check,
@@ -146,7 +146,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		"204 without changes": {
 			http.StatusNoContent,
-			mockdata.HMockUsers[1].Id,
+			mockdata.UserID2(),
 			handler.EditUserRequest{},
 			nil,
 		},
@@ -200,12 +200,12 @@ func TestGetUserAccounts(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			mockdata.HMockUserAccounts,
 		},
 		"200 no accounts with existing userID": {
 			http.StatusOK,
-			mockdata.HMockUsers[1].Id,
+			mockdata.UserID2(),
 			[]handler.Account{},
 		},
 		"400 invalid userID": {
@@ -245,31 +245,31 @@ func TestGetUserAccount(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
-			mockdata.HMockUserAccounts[0].Id,
+			mockdata.UserID1(),
+			mockdata.AccountID(),
 			mockdata.HMockUserAccounts[0],
 		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.HMockUserAccounts[0].Id,
+			mockdata.AccountID(),
 			testutils.HTTPError("bad request: nil id"),
 		},
 		"400 invalid accountID": {
 			http.StatusBadRequest,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			uuid.Nil,
 			testutils.HTTPError("bad request: nil id"),
 		},
 		"404 userID not found": {
 			http.StatusNotFound,
 			random.UUID(),
-			mockdata.HMockUserAccounts[0].Id,
+			mockdata.AccountID(),
 			testutils.HTTPError("not found: not found"),
 		},
 		"404 accountID not found": {
 			http.StatusNotFound,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			random.UUID(),
 			testutils.HTTPError("not found: not found"),
 		},
@@ -313,7 +313,7 @@ func TestAddUserAccount(t *testing.T) {
 	}{
 		"201": {
 			http.StatusCreated,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			handler.AddUserAccountJSONRequestBody{
 				DisplayName: displayName,
 				PrPermitted: handler.PrPermitted(prPermitted),
@@ -336,7 +336,7 @@ func TestAddUserAccount(t *testing.T) {
 		},
 		"400 invalid URL": {
 			http.StatusBadRequest,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			handler.AddUserAccountJSONRequestBody{
 				DisplayName: displayName,
 				PrPermitted: handler.PrPermitted(prPermitted),
@@ -347,7 +347,7 @@ func TestAddUserAccount(t *testing.T) {
 		},
 		"400 invalid account type": {
 			http.StatusBadRequest,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			handler.AddUserAccountJSONRequestBody{
 				DisplayName: displayName,
 				PrPermitted: handler.PrPermitted(prPermitted),
@@ -396,7 +396,7 @@ func TestEditUserRequestAccount(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			testutils.DummyUUID(),
 			handler.EditUserAccountJSONRequestBody{
 				DisplayName: &displayName,
@@ -408,7 +408,7 @@ func TestEditUserRequestAccount(t *testing.T) {
 		},
 		"204 without changes": { // TODO: https://github.com/traPtitech/traPortfolio/issues/292
 			http.StatusNoContent,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			testutils.DummyUUID(),
 			handler.EditUserAccountJSONRequestBody{},
 			nil,
@@ -416,13 +416,13 @@ func TestEditUserRequestAccount(t *testing.T) {
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.HMockUserAccounts[0].Id,
+			mockdata.AccountID(),
 			handler.EditUserAccountJSONRequestBody{},
 			testutils.HTTPError("bad request: nil id"),
 		},
 		"400 invalid accountID": {
 			http.StatusBadRequest,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			uuid.Nil,
 			handler.EditUserAccountJSONRequestBody{},
 			testutils.HTTPError("bad request: nil id"),
@@ -438,7 +438,7 @@ func TestEditUserRequestAccount(t *testing.T) {
 		},
 		"404 account not found": {
 			http.StatusNotFound,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			random.UUID(),
 			handler.EditUserAccountJSONRequestBody{
 				DisplayName: &displayName,
@@ -509,7 +509,7 @@ func TestDeleteUserAccount(t *testing.T) {
 	}{
 		"204": {
 			http.StatusNoContent,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			testutils.DummyUUID(),
 			nil,
 			true,
@@ -530,7 +530,7 @@ func TestDeleteUserAccount(t *testing.T) {
 		},
 		"404 account not found": {
 			http.StatusNotFound,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			random.UUID(),
 			testutils.HTTPError("not found: not found"),
 			false,
@@ -576,12 +576,12 @@ func TestGetUserProjects(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			[]handler.UserProject{mockdata.HMockUserProjects[0]},
 		},
 		"200 no projects with existing userID": {
 			http.StatusOK,
-			mockdata.HMockUsers[2].Id,
+			mockdata.UserID3(),
 			[]handler.Project{},
 		},
 		"400 invalid userID": {
@@ -620,12 +620,12 @@ func TestGetUserContests(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
-			mockdata.HMockUserContestsByID[mockdata.HMockUsers[0].Id],
+			mockdata.UserID1(),
+			mockdata.HMockUserContestsByID[mockdata.UserID1()],
 		},
 		"200 no contests with existing userID": {
 			http.StatusOK,
-			mockdata.HMockUsers[1].Id,
+			mockdata.UserID2(),
 			[]handler.Contest{},
 		},
 		"400 invalid userID": {
@@ -664,12 +664,12 @@ func TestGetUserGroups(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
-			mockdata.HMockUserGroupsByID[mockdata.HMockUsers[0].Id],
+			mockdata.UserID1(),
+			mockdata.HMockUserGroupsByID[mockdata.UserID1()],
 		},
 		"200 no groups with existing userID": {
 			http.StatusOK,
-			mockdata.HMockUsers[1].Id,
+			mockdata.UserID2(),
 			[]handler.Group{},
 		},
 		"400 invalid userID": {
@@ -708,12 +708,12 @@ func TestGetUserEvents(t *testing.T) {
 	}{
 		"200": {
 			http.StatusOK,
-			mockdata.HMockUsers[0].Id,
+			mockdata.UserID1(),
 			mockdata.HMockUserEvents,
 		},
 		"200 no events with existing userID": {
 			http.StatusOK,
-			mockdata.HMockUsers[1].Id,
+			mockdata.UserID2(),
 			[]handler.Event{
 				mockdata.HMockUserEvents[1],
 			},

--- a/integration_tests/handler/user_test.go
+++ b/integration_tests/handler/user_test.go
@@ -246,13 +246,13 @@ func TestGetUserAccount(t *testing.T) {
 		"200": {
 			http.StatusOK,
 			mockdata.UserID1(),
-			mockdata.AccountID(),
+			mockdata.AccountID1(),
 			mockdata.HMockUserAccounts[0],
 		},
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.AccountID(),
+			mockdata.AccountID1(),
 			testutils.HTTPError("bad request: nil id"),
 		},
 		"400 invalid accountID": {
@@ -264,7 +264,7 @@ func TestGetUserAccount(t *testing.T) {
 		"404 userID not found": {
 			http.StatusNotFound,
 			random.UUID(),
-			mockdata.AccountID(),
+			mockdata.AccountID1(),
 			testutils.HTTPError("not found: not found"),
 		},
 		"404 accountID not found": {
@@ -416,7 +416,7 @@ func TestEditUserRequestAccount(t *testing.T) {
 		"400 invalid userID": {
 			http.StatusBadRequest,
 			uuid.Nil,
-			mockdata.AccountID(),
+			mockdata.AccountID1(),
 			handler.EditUserAccountJSONRequestBody{},
 			testutils.HTTPError("bad request: nil id"),
 		},

--- a/util/mockdata/consts.go
+++ b/util/mockdata/consts.go
@@ -3,26 +3,6 @@ package mockdata
 import "github.com/gofrs/uuid"
 
 const (
-	userID1           uuidStr = "11111111-1111-4111-8111-111111111111"
-	userID2           uuidStr = "22222222-2222-4222-8222-222222222222"
-	userID3           uuidStr = "33333333-3333-4333-8333-333333333333"
-	accountID         uuidStr = "d834e180-2af9-4cfe-838a-8a3930666490"
-	contestID         uuidStr = "08eec963-0f29-48d1-929f-004cb67d8ce6"
-	contestTeamID     uuidStr = "a9d07124-ffee-412f-adfc-02d3db0b750d"
-	groupID           uuidStr = "455938b1-635f-4b43-ae74-66550b04c5d4"
-	projectID1        uuidStr = "bf9c1aec-7e3a-4587-8adc-651895aa6ec0"
-	projectID2        uuidStr = "bf9c1aec-7e3a-4587-8adc-651895aa6ec1"
-	projectID3        uuidStr = "bf9c1aec-7e3a-4587-8adc-651895aa6ec2"
-	projectMemberID1  uuidStr = "a211a49c-9b30-48b9-8dbb-c449c99f12c7"
-	projectMemberID2  uuidStr = "a211a49c-9b30-48b9-8dbb-c449c99f12c8"
-	projectMemberID3  uuidStr = "a211a49c-9b30-48b9-8dbb-c449c99f12c9"
-	knoqEventID1      uuidStr = "d1274c6e-15cc-4ca0-b720-1c03ea3a60ec"
-	knoqEventID2      uuidStr = "e28ec610-226d-49c5-be7c-86af54f6839d"
-	knoqEventGroupID1 uuidStr = "7ecabb2a-8e2c-4ebe-bb0b-13254a6eae05"
-	knoqEventGroupID2 uuidStr = "9c592124-52a5-4981-a2c8-1e218c64a8e5"
-	knoqEventRoomID1  uuidStr = "68319c0c-be20-45c1-a05d-7651473bd396"
-	knoqEventRoomID2  uuidStr = "cbd48b1f-6b20-41c8-b122-a9826bd968ed"
-
 	userName1     = "user1"
 	userName2     = "user2"
 	userName3     = "lolico"
@@ -30,12 +10,6 @@ const (
 	userRealname2 = "ユーザー2 ユーザー2"
 	userRealname3 = "東 工子"
 )
-
-type uuidStr string
-
-func (s uuidStr) uuid() uuid.UUID {
-	return uuid.FromStringOrNil(string(s))
-}
 
 func UserID1() uuid.UUID {
 	return uuid.FromStringOrNil("11111111-1111-4111-8111-111111111111")

--- a/util/mockdata/consts.go
+++ b/util/mockdata/consts.go
@@ -36,3 +36,79 @@ type uuidStr string
 func (s uuidStr) uuid() uuid.UUID {
 	return uuid.FromStringOrNil(string(s))
 }
+
+func UserID1() uuid.UUID {
+	return uuid.FromStringOrNil("11111111-1111-4111-8111-111111111111")
+}
+
+func UserID2() uuid.UUID {
+	return uuid.FromStringOrNil("22222222-2222-4222-8222-222222222222")
+}
+
+func UserID3() uuid.UUID {
+	return uuid.FromStringOrNil("33333333-3333-4333-8333-333333333333")
+}
+
+func AccountID() uuid.UUID {
+	return uuid.FromStringOrNil("d834e180-2af9-4cfe-838a-8a3930666490")
+}
+
+func ContestID() uuid.UUID {
+	return uuid.FromStringOrNil("08eec963-0f29-48d1-929f-004cb67d8ce6")
+}
+
+func ContestTeamID() uuid.UUID {
+	return uuid.FromStringOrNil("a9d07124-ffee-412f-adfc-02d3db0b750d")
+}
+
+func GroupID() uuid.UUID {
+	return uuid.FromStringOrNil("455938b1-635f-4b43-ae74-66550b04c5d4")
+}
+
+func ProjectID1() uuid.UUID {
+	return uuid.FromStringOrNil("bf9c1aec-7e3a-4587-8adc-651895aa6ec0")
+}
+
+func ProjectID2() uuid.UUID {
+	return uuid.FromStringOrNil("bf9c1aec-7e3a-4587-8adc-651895aa6ec1")
+}
+
+func ProjectID3() uuid.UUID {
+	return uuid.FromStringOrNil("bf9c1aec-7e3a-4587-8adc-651895aa6ec2")
+}
+
+func ProjectMemberID1() uuid.UUID {
+	return uuid.FromStringOrNil("a211a49c-9b30-48b9-8dbb-c449c99f12c7")
+}
+
+func ProjectMemberID2() uuid.UUID {
+	return uuid.FromStringOrNil("a211a49c-9b30-48b9-8dbb-c449c99f12c8")
+}
+
+func ProjectMemberID3() uuid.UUID {
+	return uuid.FromStringOrNil("a211a49c-9b30-48b9-8dbb-c449c99f12c9")
+}
+
+func KnoqEventID1() uuid.UUID {
+	return uuid.FromStringOrNil("d1274c6e-15cc-4ca0-b720-1c03ea3a60ec")
+}
+
+func KnoqEventID2() uuid.UUID {
+	return uuid.FromStringOrNil("e28ec610-226d-49c5-be7c-86af54f6839d")
+}
+
+func KnoqEventGroupID1() uuid.UUID {
+	return uuid.FromStringOrNil("7ecabb2a-8e2c-4ebe-bb0b-13254a6eae05")
+}
+
+func KnoqEventGroupID2() uuid.UUID {
+	return uuid.FromStringOrNil("9c592124-52a5-4981-a2c8-1e218c64a8e5")
+}
+
+func KnoqEventRoomID1() uuid.UUID {
+	return uuid.FromStringOrNil("68319c0c-be20-45c1-a05d-7651473bd396")
+}
+
+func KnoqEventRoomID2() uuid.UUID {
+	return uuid.FromStringOrNil("cbd48b1f-6b20-41c8-b122-a9826bd968ed")
+}

--- a/util/mockdata/consts.go
+++ b/util/mockdata/consts.go
@@ -23,19 +23,19 @@ func UserID3() uuid.UUID {
 	return uuid.FromStringOrNil("33333333-3333-4333-8333-333333333333")
 }
 
-func AccountID() uuid.UUID {
+func AccountID1() uuid.UUID {
 	return uuid.FromStringOrNil("d834e180-2af9-4cfe-838a-8a3930666490")
 }
 
-func ContestID() uuid.UUID {
+func ContestID1() uuid.UUID {
 	return uuid.FromStringOrNil("08eec963-0f29-48d1-929f-004cb67d8ce6")
 }
 
-func ContestTeamID() uuid.UUID {
+func ContestTeamID1() uuid.UUID {
 	return uuid.FromStringOrNil("a9d07124-ffee-412f-adfc-02d3db0b750d")
 }
 
-func GroupID() uuid.UUID {
+func GroupID1() uuid.UUID {
 	return uuid.FromStringOrNil("455938b1-635f-4b43-ae74-66550b04c5d4")
 }
 

--- a/util/mockdata/external.go
+++ b/util/mockdata/external.go
@@ -22,33 +22,33 @@ var (
 func CloneMockKnoqEvents() []*external.EventResponse {
 	return []*external.EventResponse{
 		{
-			ID:          knoqEventID1.uuid(),
+			ID:          KnoqEventID1(),
 			Name:        "第n回進捗回",
 			Description: "第n回の進捗会です。",
 			Place:       "S516",
-			GroupID:     knoqEventGroupID1.uuid(),
-			RoomID:      knoqEventRoomID1.uuid(),
+			GroupID:     KnoqEventGroupID1(),
+			RoomID:      KnoqEventRoomID1(),
 			TimeStart:   time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			TimeEnd:     time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
 			SharedRoom:  true,
 			Admins: []uuid.UUID{
-				userID1.uuid(),
+				UserID1(),
 			},
 		},
 		{
-			ID:          knoqEventID2.uuid(),
+			ID:          KnoqEventID2(),
 			Name:        "sample event",
 			Description: "This is a sample event.",
 			Place:       "S516",
-			GroupID:     knoqEventGroupID2.uuid(),
-			RoomID:      knoqEventRoomID2.uuid(),
+			GroupID:     KnoqEventGroupID2(),
+			RoomID:      KnoqEventRoomID2(),
 			TimeStart:   time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			TimeEnd:     time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
 			SharedRoom:  false,
 			Admins: []uuid.UUID{
-				userID1.uuid(),
-				userID2.uuid(),
-				userID3.uuid(),
+				UserID1(),
+				UserID2(),
+				UserID3(),
 			},
 		},
 	}
@@ -78,21 +78,21 @@ func CloneMockTraQUsers() []*TraQUser {
 	return []*TraQUser{
 		{
 			User: &external.TraQUserResponse{
-				ID:    userID1.uuid(),
+				ID:    UserID1(),
 				State: domain.TraqStateActive,
 			},
 			Name: userName1,
 		},
 		{
 			User: &external.TraQUserResponse{
-				ID:    userID2.uuid(),
+				ID:    UserID2(),
 				State: domain.TraqStateDeactivated,
 			},
 			Name: userName2,
 		},
 		{
 			User: &external.TraQUserResponse{
-				ID:    userID3.uuid(),
+				ID:    UserID3(),
 				State: domain.TraqStateActive,
 			},
 			Name: userName3,

--- a/util/mockdata/handler.go
+++ b/util/mockdata/handler.go
@@ -355,7 +355,7 @@ func CloneHandlerMockUserDetails() []handler.UserDetail {
 			State:    handler.UserAccountState(traqUsers[i].User.State),
 		}
 
-		if mu.ID == userID1.uuid() {
+		if mu.ID == UserID1() {
 			hUsers[i].Accounts = hAccounts
 		}
 	}

--- a/util/mockdata/model.go
+++ b/util/mockdata/model.go
@@ -47,7 +47,7 @@ func CloneMockUsers() []*model.User {
 
 func CloneMockAccount() model.Account {
 	return model.Account{
-		ID:     AccountID(),
+		ID:     AccountID1(),
 		Type:   0,
 		Name:   "sample_account_display_name",
 		URL:    "https://sample.accounts.com",
@@ -59,7 +59,7 @@ func CloneMockAccount() model.Account {
 func CloneMockContests() []model.Contest {
 	return []model.Contest{
 		{
-			ID:          ContestID(),
+			ID:          ContestID1(),
 			Name:        "sample_contest_name",
 			Description: "sample_contest_description",
 			Link:        "https://sample.contests.com",
@@ -72,8 +72,8 @@ func CloneMockContests() []model.Contest {
 func CloneMockContestTeams() []model.ContestTeam {
 	return []model.ContestTeam{
 		{
-			ID:          ContestTeamID(),
-			ContestID:   ContestID(),
+			ID:          ContestTeamID1(),
+			ContestID:   ContestID1(),
 			Name:        "sample_contest_team_name",
 			Description: "sample_contest_team_description",
 			Result:      "sample_contest_team_result",
@@ -85,7 +85,7 @@ func CloneMockContestTeams() []model.ContestTeam {
 func CloneMockContestTeamUserBelongings() []model.ContestTeamUserBelonging {
 	return []model.ContestTeamUserBelonging{
 		{
-			TeamID: ContestTeamID(),
+			TeamID: ContestTeamID1(),
 			UserID: UserID1(),
 		},
 	}
@@ -107,7 +107,7 @@ func CloneMockEventLevelRelations() []model.EventLevelRelation {
 func CloneMockGroups() []model.Group {
 	return []model.Group{
 		{
-			GroupID:     GroupID(),
+			GroupID:     GroupID1(),
 			Name:        "sample_group_name",
 			Link:        "https://sample.groups.com",
 			Description: "sample_group_description",
@@ -119,7 +119,7 @@ func CloneMockGroupUserBelongings() []model.GroupUserBelonging {
 	return []model.GroupUserBelonging{
 		{
 			UserID:        UserID1(),
-			GroupID:       GroupID(),
+			GroupID:       GroupID1(),
 			SinceYear:     2022,
 			SinceSemester: 0,
 			UntilYear:     2022,
@@ -132,7 +132,7 @@ func CloneMockGroupUserAdmins() []model.GroupUserAdmin {
 	return []model.GroupUserAdmin{
 		{
 			UserID:  UserID1(),
-			GroupID: GroupID(),
+			GroupID: GroupID1(),
 		},
 	}
 }

--- a/util/mockdata/model.go
+++ b/util/mockdata/model.go
@@ -25,19 +25,19 @@ var (
 func CloneMockUsers() []*model.User {
 	return []*model.User{
 		{
-			ID:          userID1.uuid(),
+			ID:          UserID1(),
 			Description: "I am user1",
 			Check:       true,
 			Name:        userName1,
 		},
 		{
-			ID:          userID2.uuid(),
+			ID:          UserID2(),
 			Description: "I am user2",
 			Check:       true,
 			Name:        userName2,
 		},
 		{
-			ID:          userID3.uuid(),
+			ID:          UserID3(),
 			Description: "I am lolico",
 			Check:       false,
 			Name:        userName3,
@@ -47,11 +47,11 @@ func CloneMockUsers() []*model.User {
 
 func CloneMockAccount() model.Account {
 	return model.Account{
-		ID:     accountID.uuid(),
+		ID:     AccountID(),
 		Type:   0,
 		Name:   "sample_account_display_name",
 		URL:    "https://sample.accounts.com",
-		UserID: userID1.uuid(),
+		UserID: UserID1(),
 		Check:  true,
 	}
 }
@@ -59,7 +59,7 @@ func CloneMockAccount() model.Account {
 func CloneMockContests() []model.Contest {
 	return []model.Contest{
 		{
-			ID:          contestID.uuid(),
+			ID:          ContestID(),
 			Name:        "sample_contest_name",
 			Description: "sample_contest_description",
 			Link:        "https://sample.contests.com",
@@ -72,8 +72,8 @@ func CloneMockContests() []model.Contest {
 func CloneMockContestTeams() []model.ContestTeam {
 	return []model.ContestTeam{
 		{
-			ID:          contestTeamID.uuid(),
-			ContestID:   contestID.uuid(),
+			ID:          ContestTeamID(),
+			ContestID:   ContestID(),
 			Name:        "sample_contest_team_name",
 			Description: "sample_contest_team_description",
 			Result:      "sample_contest_team_result",
@@ -85,8 +85,8 @@ func CloneMockContestTeams() []model.ContestTeam {
 func CloneMockContestTeamUserBelongings() []model.ContestTeamUserBelonging {
 	return []model.ContestTeamUserBelonging{
 		{
-			TeamID: contestTeamID.uuid(),
-			UserID: userID1.uuid(),
+			TeamID: ContestTeamID(),
+			UserID: UserID1(),
 		},
 	}
 }
@@ -94,11 +94,11 @@ func CloneMockContestTeamUserBelongings() []model.ContestTeamUserBelonging {
 func CloneMockEventLevelRelations() []model.EventLevelRelation {
 	return []model.EventLevelRelation{
 		{
-			ID:    knoqEventID1.uuid(),
+			ID:    KnoqEventID1(),
 			Level: domain.EventLevelPublic,
 		},
 		{
-			ID:    knoqEventID2.uuid(),
+			ID:    KnoqEventID2(),
 			Level: domain.EventLevelPrivate,
 		},
 	}
@@ -107,7 +107,7 @@ func CloneMockEventLevelRelations() []model.EventLevelRelation {
 func CloneMockGroups() []model.Group {
 	return []model.Group{
 		{
-			GroupID:     groupID.uuid(),
+			GroupID:     GroupID(),
 			Name:        "sample_group_name",
 			Link:        "https://sample.groups.com",
 			Description: "sample_group_description",
@@ -118,8 +118,8 @@ func CloneMockGroups() []model.Group {
 func CloneMockGroupUserBelongings() []model.GroupUserBelonging {
 	return []model.GroupUserBelonging{
 		{
-			UserID:        userID1.uuid(),
-			GroupID:       groupID.uuid(),
+			UserID:        UserID1(),
+			GroupID:       GroupID(),
 			SinceYear:     2022,
 			SinceSemester: 0,
 			UntilYear:     2022,
@@ -131,8 +131,8 @@ func CloneMockGroupUserBelongings() []model.GroupUserBelonging {
 func CloneMockGroupUserAdmins() []model.GroupUserAdmin {
 	return []model.GroupUserAdmin{
 		{
-			UserID:  userID1.uuid(),
-			GroupID: groupID.uuid(),
+			UserID:  UserID1(),
+			GroupID: GroupID(),
 		},
 	}
 }
@@ -140,7 +140,7 @@ func CloneMockGroupUserAdmins() []model.GroupUserAdmin {
 func CloneMockProjects() []*model.Project {
 	return []*model.Project{
 		{
-			ID:            projectID1.uuid(),
+			ID:            ProjectID1(),
 			Name:          "sample_project_name1",
 			Description:   "sample_project_description1",
 			Link:          "https://sample.project1.com",
@@ -150,7 +150,7 @@ func CloneMockProjects() []*model.Project {
 			UntilSemester: 1,
 		},
 		{
-			ID:            projectID2.uuid(),
+			ID:            ProjectID2(),
 			Name:          "sample_project_name2",
 			Description:   "sample_project_description2",
 			Link:          "https://sample.project2.com",
@@ -160,7 +160,7 @@ func CloneMockProjects() []*model.Project {
 			UntilSemester: 1,
 		},
 		{
-			ID:            projectID3.uuid(),
+			ID:            ProjectID3(),
 			Name:          "sample_project_name3",
 			Description:   "sample_project_description3",
 			Link:          "https://sample.project3.com",
@@ -175,27 +175,27 @@ func CloneMockProjects() []*model.Project {
 func CloneMockProjectMembers() []*model.ProjectMember {
 	return []*model.ProjectMember{
 		{
-			ID:            projectMemberID1.uuid(),
-			ProjectID:     projectID1.uuid(),
-			UserID:        userID1.uuid(),
+			ID:            ProjectMemberID1(),
+			ProjectID:     ProjectID1(),
+			UserID:        UserID1(),
 			SinceYear:     2021,
 			SinceSemester: 0,
 			UntilYear:     2021,
 			UntilSemester: 1,
 		},
 		{
-			ID:            projectMemberID2.uuid(),
-			ProjectID:     projectID1.uuid(),
-			UserID:        userID2.uuid(),
+			ID:            ProjectMemberID2(),
+			ProjectID:     ProjectID1(),
+			UserID:        UserID2(),
 			SinceYear:     2022,
 			SinceSemester: 0,
 			UntilYear:     2022,
 			UntilSemester: 1,
 		},
 		{
-			ID:            projectMemberID3.uuid(),
-			ProjectID:     projectID2.uuid(),
-			UserID:        userID2.uuid(),
+			ID:            ProjectMemberID3(),
+			ProjectID:     ProjectID2(),
+			UserID:        UserID2(),
 			SinceYear:     2021,
 			SinceSemester: 0,
 			UntilYear:     2022,


### PR DESCRIPTION
mockdata/consts.go の 〜ID の部分をパブリックな関数にした
integration_tests の HMock〜.Id となっている部分を↑で作ったパブリックな関数にした

なんかテスト通ってないっぽい(?)ですが、比較も兼ねて一旦 PR 出します