### PR TITLE
infrastructure.NewSQLHandlerには構造体のコンストラクタとしての役割だけを持たせる

### DIFF
--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -15,6 +15,10 @@ type SQLHandler struct {
 	conn *gorm.DB
 }
 
+func NewSQLHandler(db *gorm.DB) database.SQLHandler {
+	return &SQLHandler{conn: db}
+}
+
 func NewGormDB(conf *config.SQLConfig) (*gorm.DB, error) {
 	engine, err := gorm.Open(
 		mysql.New(mysql.Config{DSN: conf.Dsn()}),
@@ -36,10 +40,6 @@ func NewGormDB(conf *config.SQLConfig) (*gorm.DB, error) {
 	}
 
 	return engine, nil
-}
-
-func NewSQLHandler(db *gorm.DB) database.SQLHandler {
-	return &SQLHandler{conn: db}
 }
 
 // initDB データベースのスキーマを更新

--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -38,7 +38,7 @@ func NewGormDB(conf *config.SQLConfig) (*gorm.DB, error) {
 	return engine, nil
 }
 
-func FromDB(db *gorm.DB) database.SQLHandler {
+func NewSQLHandler(db *gorm.DB) database.SQLHandler {
 	return &SQLHandler{conn: db}
 }
 

--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -15,15 +15,15 @@ type SQLHandler struct {
 	conn *gorm.DB
 }
 
-func NewSQLHandler(conf *config.SQLConfig) (database.SQLHandler, error) {
+func NewGormDB(conf *config.SQLConfig) (*gorm.DB, error) {
 	engine, err := gorm.Open(
 		mysql.New(mysql.Config{DSN: conf.Dsn()}),
 		conf.GormConfig(),
 	)
 	if err != nil {
-		// return fmt.Errorf("failed to connect database: %v", err)s
 		return nil, err
 	}
+
 	db, err := engine.DB()
 	if err != nil {
 		return nil, err
@@ -35,9 +35,7 @@ func NewSQLHandler(conf *config.SQLConfig) (database.SQLHandler, error) {
 		return nil, err
 	}
 
-	sqlHandler := new(SQLHandler)
-	sqlHandler.conn = engine
-	return sqlHandler, nil
+	return engine, nil
 }
 
 func FromDB(db *gorm.DB) database.SQLHandler {

--- a/infrastructure/wire.go
+++ b/infrastructure/wire.go
@@ -47,7 +47,7 @@ var contestSet = wire.NewSet(
 )
 
 var sqlSet = wire.NewSet(
-	FromDB,
+	NewSQLHandler,
 )
 
 var externalSet = wire.NewSet(

--- a/infrastructure/wire.go
+++ b/infrastructure/wire.go
@@ -9,6 +9,7 @@ import (
 	impl "github.com/traPtitech/traPortfolio/interfaces/repository"
 	"github.com/traPtitech/traPortfolio/usecases/service"
 	"github.com/traPtitech/traPortfolio/util/config"
+	"gorm.io/gorm"
 )
 
 var pingSet = wire.NewSet(
@@ -46,7 +47,7 @@ var contestSet = wire.NewSet(
 )
 
 var sqlSet = wire.NewSet(
-	NewSQLHandler,
+	FromDB,
 )
 
 var externalSet = wire.NewSet(
@@ -59,19 +60,17 @@ var apiSet = wire.NewSet(handler.NewAPI)
 
 var confSet = wire.NewSet(
 	provideIsDevelopMent,
-	provideSQLConf,
 	provideTraqConf,
 	provideKnoqConf,
 	providePortalConf,
 )
 
-func provideIsDevelopMent(c *config.Config) bool		  				{ return c.IsDevelopment() }
-func provideSQLConf(c *config.Config) *config.SQLConfig       { return c.SQLConf() }
+func provideIsDevelopMent(c *config.Config) bool              { return c.IsDevelopment() }
 func provideTraqConf(c *config.Config) *config.TraqConfig     { return c.TraqConf() }
 func provideKnoqConf(c *config.Config) *config.KnoqConfig     { return c.KnoqConf() }
 func providePortalConf(c *config.Config) *config.PortalConfig { return c.PortalConf() }
 
-func InjectAPIServer(c *config.Config) (handler.API, error) {
+func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 	wire.Build(
 		pingSet,
 		userSet,

--- a/infrastructure/wire_gen.go
+++ b/infrastructure/wire_gen.go
@@ -12,17 +12,14 @@ import (
 	"github.com/traPtitech/traPortfolio/interfaces/repository"
 	"github.com/traPtitech/traPortfolio/usecases/service"
 	"github.com/traPtitech/traPortfolio/util/config"
+	"gorm.io/gorm"
 )
 
 // Injectors from wire.go:
 
-func InjectAPIServer(c *config.Config) (handler.API, error) {
+func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 	pingHandler := handler.NewPingHandler()
-	sqlConfig := provideSQLConf(c)
-	sqlHandler, err := NewSQLHandler(sqlConfig)
-	if err != nil {
-		return handler.API{}, err
-	}
+	sqlHandler := FromDB(db)
 	portalConfig := providePortalConf(c)
 	bool2 := provideIsDevelopMent(c)
 	portalAPI, err := NewPortalAPI(portalConfig, bool2)
@@ -73,7 +70,7 @@ var groupSet = wire.NewSet(repository.NewGroupRepository, service.NewGroupServic
 var contestSet = wire.NewSet(repository.NewContestRepository, service.NewContestService, handler.NewContestHandler)
 
 var sqlSet = wire.NewSet(
-	NewSQLHandler,
+	FromDB,
 )
 
 var externalSet = wire.NewSet(
@@ -86,15 +83,12 @@ var apiSet = wire.NewSet(handler.NewAPI)
 
 var confSet = wire.NewSet(
 	provideIsDevelopMent,
-	provideSQLConf,
 	provideTraqConf,
 	provideKnoqConf,
 	providePortalConf,
 )
 
 func provideIsDevelopMent(c *config.Config) bool { return c.IsDevelopment() }
-
-func provideSQLConf(c *config.Config) *config.SQLConfig { return c.SQLConf() }
 
 func provideTraqConf(c *config.Config) *config.TraqConfig { return c.TraqConf() }
 

--- a/infrastructure/wire_gen.go
+++ b/infrastructure/wire_gen.go
@@ -19,7 +19,7 @@ import (
 
 func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 	pingHandler := handler.NewPingHandler()
-	sqlHandler := FromDB(db)
+	sqlHandler := NewSQLHandler(db)
 	portalConfig := providePortalConf(c)
 	bool2 := provideIsDevelopMent(c)
 	portalAPI, err := NewPortalAPI(portalConfig, bool2)
@@ -70,7 +70,7 @@ var groupSet = wire.NewSet(repository.NewGroupRepository, service.NewGroupServic
 var contestSet = wire.NewSet(repository.NewContestRepository, service.NewContestService, handler.NewContestHandler)
 
 var sqlSet = wire.NewSet(
-	FromDB,
+	NewSQLHandler,
 )
 
 var externalSet = wire.NewSet(

--- a/integration_tests/repository/contest_test.go
+++ b/integration_tests/repository/contest_test.go
@@ -22,7 +22,7 @@ func TestContestRepository_GetContests(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_get_contests")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
@@ -40,7 +40,7 @@ func TestContestRepository_GetContest(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_get_contest")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
@@ -60,7 +60,7 @@ func TestContestRepository_UpdateContest(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_update_contest")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
@@ -116,7 +116,7 @@ func TestContestRepository_DeleteContest(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_delete_contest")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
@@ -147,7 +147,7 @@ func TestContestRepository_GetContestTeams(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_get_contest_teams")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	contest1 := mustMakeContest(t, repo, nil)
@@ -181,7 +181,7 @@ func TestContestRepository_GetContestTeam(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("contest_repository_get_contest_team")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	contest1 := mustMakeContest(t, repo, nil)
@@ -216,7 +216,7 @@ func TestContestRepository_UpdateContestTeam(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("contest_repository_update_contest_teams")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	contest1 := mustMakeContest(t, repo, nil)
@@ -267,7 +267,7 @@ func TestContestRepository_DeleteContestTeam(t *testing.T) {
 	conf := testutils.GetConfigWithDBName("contest_repository_delete_contest_teams")
 	sqlConf := conf.SQLConf()
 
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	contest1 := mustMakeContest(t, repo, nil)
@@ -315,7 +315,7 @@ func TestContestRepository_GetContestTeamMembers(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("contest_repository_get_contest_team_members")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
@@ -390,7 +390,7 @@ func TestContestRepository_EditContestTeamMembers(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("contest_repository_edit_contest_team_members")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())

--- a/integration_tests/repository/event_test.go
+++ b/integration_tests/repository/event_test.go
@@ -21,7 +21,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("event_repository_get_events")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewEventRepository(h, mock_external_e2e.NewMockKnoqAPI())
 
 	expected := make([]*domain.Event, 0)
@@ -45,7 +45,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("event_repository_get_event")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewEventRepository(h, mock_external_e2e.NewMockKnoqAPI())
 
 	levels := createRandomEventLevels(t, repo)
@@ -91,7 +91,7 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("event_repository_update_event_level")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewEventRepository(h, mock_external_e2e.NewMockKnoqAPI())
 
 	levels := createRandomEventLevels(t, repo)
@@ -123,7 +123,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("event_repository_get_user_events")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewEventRepository(h, mock_external_e2e.NewMockKnoqAPI())
 
 	expected := make([]*domain.Event, 0)

--- a/integration_tests/repository/project_test.go
+++ b/integration_tests/repository/project_test.go
@@ -23,7 +23,7 @@ func TestProjectRepository_GetProjects(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("project_repository_get_projects")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewProjectRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	projectNum := 4
@@ -43,7 +43,7 @@ func TestProjectRepository_GetProject(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("project_repository_get_project")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewProjectRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	projectNum := 4
@@ -71,7 +71,7 @@ func TestProjectRepository_UpdateProject(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("project_repository_update_project")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewProjectRepository(h, mock_external_e2e.NewMockPortalAPI())
 
 	project1 := mustMakeProjectDetail(t, repo, nil)
@@ -122,7 +122,7 @@ func TestProjectRepository_GetProjectMembers(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("project_repository_get_project_members")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewProjectRepository(h, mock_external_e2e.NewMockPortalAPI())
@@ -216,7 +216,7 @@ func TestProjectRepository_DeleteProjectMembers(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("project_repository_delete_project_members")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewProjectRepository(h, mock_external_e2e.NewMockPortalAPI())

--- a/integration_tests/repository/user_test.go
+++ b/integration_tests/repository/user_test.go
@@ -22,7 +22,7 @@ func TestUserRepository_GetUsers(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_users")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -116,7 +116,7 @@ func TestUserRepository_GetUser(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_user")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -197,7 +197,7 @@ func TestUserRepository_CreateUser(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_create_user")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
 
 	type args struct {
@@ -249,7 +249,7 @@ func TestUserRepository_UpdateUser(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_update_user")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -294,7 +294,7 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_accounts")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -316,7 +316,7 @@ func TestUserRepository_GetAccount(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_account")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -339,7 +339,7 @@ func TestUserRepository_UpdateAccount(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_update_account")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -380,7 +380,7 @@ func TestUserRepository_DeleteAccount(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_delete_account")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	repo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -406,7 +406,7 @@ func TestUserRepository_GetUserProjects(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_user_projects")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	userRepo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())
@@ -439,7 +439,7 @@ func TestUserRepository_GetContests(t *testing.T) {
 
 	conf := testutils.GetConfigWithDBName("user_repository_get_contests")
 	sqlConf := conf.SQLConf()
-	h := testutils.SetupDB(t, sqlConf)
+	h := testutils.SetupSQLHandler(t, sqlConf)
 	err := mockdata.InsertSampleDataToDB(h)
 	assert.NoError(t, err)
 	userRepo := irepository.NewUserRepository(h, mock_external_e2e.NewMockPortalAPI(), mock_external_e2e.NewMockTraQAPI())

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -32,7 +32,7 @@ func SetupGormDB(t *testing.T, sqlConf *config.SQLConfig) *gorm.DB {
 	return db
 }
 
-func SetupDB(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
+func SetupSQLHandler(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
 	t.Helper()
 
 	db := SetupGormDB(t, sqlConf)

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -16,7 +16,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func SetupDB(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
+func SetupGormDB(t *testing.T, sqlConf *config.SQLConfig) *gorm.DB {
 	t.Helper()
 
 	db := establishTestDBConnection(t, sqlConf)
@@ -28,6 +28,15 @@ func SetupDB(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
 		panic(err)
 	}
 	assert.NoError(t, err)
+
+	return db
+}
+
+func SetupDB(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
+	t.Helper()
+
+	db := SetupGormDB(t, sqlConf)
+
 	h := infrastructure.FromDB(db)
 	return h
 }

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -37,7 +37,7 @@ func SetupDB(t *testing.T, sqlConf *config.SQLConfig) database.SQLHandler {
 
 	db := SetupGormDB(t, sqlConf)
 
-	h := infrastructure.FromDB(db)
+	h := infrastructure.NewSQLHandler(db)
 	return h
 }
 

--- a/integration_tests/testutils/router.go
+++ b/integration_tests/testutils/router.go
@@ -21,7 +21,7 @@ func SetupRoutes(t *testing.T, e *echo.Echo, conf *config.Config) (*handler.API,
 	t.Helper()
 
 	db := SetupGormDB(t, conf.SQLConf())
-	if err := mockdata.InsertSampleDataToDB(infrastructure.FromDB(db)); err != nil { // TODO: tmp
+	if err := mockdata.InsertSampleDataToDB(infrastructure.NewSQLHandler(db)); err != nil {
 		return nil, err
 	}
 

--- a/integration_tests/testutils/router.go
+++ b/integration_tests/testutils/router.go
@@ -20,12 +20,12 @@ import (
 func SetupRoutes(t *testing.T, e *echo.Echo, conf *config.Config) (*handler.API, error) {
 	t.Helper()
 
-	db := SetupDB(t, conf.SQLConf())
-	if err := mockdata.InsertSampleDataToDB(db); err != nil {
+	db := SetupGormDB(t, conf.SQLConf())
+	if err := mockdata.InsertSampleDataToDB(infrastructure.FromDB(db)); err != nil { // TODO: tmp
 		return nil, err
 	}
 
-	api, err := infrastructure.InjectAPIServer(conf)
+	api, err := infrastructure.InjectAPIServer(conf, db)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -15,10 +15,11 @@ func main() {
 	appConf := config.GetConfig()
 	s := appConf.SQLConf()
 	// migration
-	h, err := infrastructure.NewSQLHandler(s)
+	db, err := infrastructure.NewGormDB(s)
 	if err != nil {
 		log.Fatal(err)
 	}
+	h := infrastructure.FromDB(db) // TODO: tmp
 
 	if appConf.IsMigrate() {
 		log.Println("migration finished")
@@ -35,7 +36,7 @@ func main() {
 		}
 	}
 
-	api, err := infrastructure.InjectAPIServer(appConf)
+	api, err := infrastructure.InjectAPIServer(appConf, db)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -12,14 +12,12 @@ import (
 
 func main() {
 	config.Parse()
+
 	appConf := config.GetConfig()
-	s := appConf.SQLConf()
-	// migration
-	db, err := infrastructure.NewGormDB(s)
+	db, err := infrastructure.NewGormDB(appConf.SQLConf())
 	if err != nil {
 		log.Fatal(err)
 	}
-	h := infrastructure.FromDB(db) // TODO: tmp
 
 	if appConf.IsMigrate() {
 		log.Println("migration finished")
@@ -31,7 +29,7 @@ func main() {
 			log.Fatal("cannot specify both `production` and `insert-mock-data`")
 		}
 
-		if err := mockdata.InsertSampleDataToDB(h); err != nil {
+		if err := mockdata.InsertSampleDataToDB(infrastructure.FromDB(db)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 			log.Fatal("cannot specify both `production` and `insert-mock-data`")
 		}
 
-		if err := mockdata.InsertSampleDataToDB(infrastructure.FromDB(db)); err != nil {
+		if err := mockdata.InsertSampleDataToDB(infrastructure.NewSQLHandler(db)); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
- :recycle: infrastructure.NewSQLHandler -> NewGormDB
- :recycle: format code
- :truck: rename FromDB -> NewSQLHandler
- :recycle: format code
