### PR TITLE
GET /users/:id/contestsでContestTeamの情報が返ってるのを修正

### DIFF
--- a/docs/swagger/traPortfolio.v1.yaml
+++ b/docs/swagger/traPortfolio.v1.yaml
@@ -1118,8 +1118,13 @@ components:
           properties:
             team:
               $ref: '#/components/schemas/ContestTeam'
+            teamCount:
+              type: integer
+              x-go-type: uint8
+              description: チーム数
           required:
             - team
+            - teamCount
     ContestDetail:
       title: ContestDetail
       type: object

--- a/docs/swagger/traPortfolio.v1.yaml
+++ b/docs/swagger/traPortfolio.v1.yaml
@@ -140,7 +140,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/userIdInPath'
     get:
-      summary: ユーザーが参加したコンテストチームの取得
+      summary: ユーザーが参加したコンテストの取得
       responses:
         '200':
           description: OK
@@ -149,7 +149,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContestTeamWithContestName'
+                  $ref: '#/components/schemas/UserContest'
         '404':
           description: Not Found
       operationId: getUserContests
@@ -1108,6 +1108,18 @@ components:
         - id
         - name
         - duration
+    UserContest:
+      title: UserContest
+      type: object
+      description: ユーザーが参加したコンテストの情報
+      allOf:
+        - $ref: '#/components/schemas/Contest'
+        - type: object
+          properties:
+            team:
+              $ref: '#/components/schemas/ContestTeam'
+          required:
+            - team
     ContestDetail:
       title: ContestDetail
       type: object
@@ -1176,19 +1188,6 @@ components:
             - link
             - description
             - members
-    ContestTeamWithContestName:
-      title: ContestTeamWithContestName
-      type: object
-      description: コンテストチーム情報(コンテスト名含む)
-      allOf:
-        - $ref: '#/components/schemas/ContestTeam'
-        - type: object
-          properties:
-            contestName:
-              type: string
-              description: コンテスト名
-          required:
-            - contestName
     PrPermitted:
       title: PrPermitted
       type: boolean


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio/issues/440