### PR TITLE
gormのクエリ発行にWithContextを付加する

### DIFF
--- a/infrastructure/sqlhandler.go
+++ b/infrastructure/sqlhandler.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"context"
 	"errors"
 
 	sqldriver "github.com/go-sql-driver/mysql"
@@ -50,6 +51,11 @@ func initDB(db *gorm.DB) error {
 		return err
 	}
 	return nil
+}
+
+func (h *SQLHandler) WithContext(ctx context.Context) database.SQLHandler {
+	db := h.conn.WithContext(ctx)
+	return &SQLHandler{conn: db}
 }
 
 func (h *SQLHandler) Find(out interface{}, where ...interface{}) database.SQLHandler {

--- a/integration_tests/repository/contest_test.go
+++ b/integration_tests/repository/contest_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -26,7 +27,7 @@ func TestContestRepository_GetContests(t *testing.T) {
 	repo := irepository.NewContestRepository(h, mock_external_e2e.NewMockPortalAPI())
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
-	contests, err := repo.GetContests()
+	contests, err := repo.GetContests(context.Background())
 	assert.NoError(t, err)
 
 	expected := []*domain.Contest{&contest1.Contest, &contest2.Contest}
@@ -45,11 +46,11 @@ func TestContestRepository_GetContest(t *testing.T) {
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
 
-	gotContest1, err := repo.GetContest(contest1.ID)
+	gotContest1, err := repo.GetContest(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, contest1, gotContest1)
 
-	gotContest2, err := repo.GetContest(contest2.ID)
+	gotContest2, err := repo.GetContest(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, contest2, gotContest2)
 }
@@ -88,12 +89,12 @@ func TestContestRepository_UpdateContest(t *testing.T) {
 		contest1.TimeEnd = args.Until.Time
 	}
 
-	err := repo.UpdateContest(contest1.ID, &args)
+	err := repo.UpdateContest(context.Background(), contest1.ID, &args)
 	assert.NoError(t, err)
 
-	gotContest1, err := repo.GetContest(contest1.ID)
+	gotContest1, err := repo.GetContest(context.Background(), contest1.ID)
 	assert.NoError(t, err)
-	gotContest2, err := repo.GetContest(contest2.ID)
+	gotContest2, err := repo.GetContest(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 
 	expected := []*domain.ContestDetail{contest1, contest2}
@@ -121,22 +122,22 @@ func TestContestRepository_DeleteContest(t *testing.T) {
 	contest1 := mustMakeContest(t, repo, nil)
 	contest2 := mustMakeContest(t, repo, nil)
 
-	gotContest1, err := repo.GetContest(contest1.ID)
+	gotContest1, err := repo.GetContest(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, contest1, gotContest1)
 
-	gotContest2, err := repo.GetContest(contest2.ID)
+	gotContest2, err := repo.GetContest(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, contest2, gotContest2)
 
-	err = repo.DeleteContest(contest1.ID)
+	err = repo.DeleteContest(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 
-	deletedContest1, err := repo.GetContest(contest1.ID)
+	deletedContest1, err := repo.GetContest(context.Background(), contest1.ID)
 	assert.Nil(t, deletedContest1)
 	assert.Equal(t, err, urepository.ErrNotFound)
 
-	gotContest2, err = repo.GetContest(contest2.ID)
+	gotContest2, err = repo.GetContest(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, contest2, gotContest2)
 }
@@ -166,12 +167,12 @@ func TestContestRepository_GetContestTeams(t *testing.T) {
 	})
 
 	expected1 := []*domain.ContestTeam{&team1.ContestTeam, &team2.ContestTeam}
-	gotTeams1, err := repo.GetContestTeams(contest1.ID)
+	gotTeams1, err := repo.GetContestTeams(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, gotTeams1)
 
 	expected2 := []*domain.ContestTeam{}
-	gotTeams2, err := repo.GetContestTeams(contest2.ID)
+	gotTeams2, err := repo.GetContestTeams(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, gotTeams2)
 }
@@ -199,11 +200,11 @@ func TestContestRepository_GetContestTeam(t *testing.T) {
 		Description: random.AlphaNumeric(),
 	})
 
-	gotTeams1, err := repo.GetContestTeam(contest1.ID, team1.ID)
+	gotTeams1, err := repo.GetContestTeam(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, team1, gotTeams1)
 
-	gotTeams2, err := repo.GetContestTeam(contest2.ID, team2.ID)
+	gotTeams2, err := repo.GetContestTeam(context.Background(), contest2.ID, team2.ID)
 	assert.Error(t, err)
 	assert.Nil(t, gotTeams2)
 }
@@ -253,10 +254,10 @@ func TestContestRepository_UpdateContestTeam(t *testing.T) {
 		team1.Description = args1.Description.String
 	}
 
-	err := repo.UpdateContestTeam(team1.ID, args1)
+	err := repo.UpdateContestTeam(context.Background(), team1.ID, args1)
 	assert.NoError(t, err)
 
-	got, err := repo.GetContestTeam(contest1.ID, team1.ID)
+	got, err := repo.GetContestTeam(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, team1, got)
 }
@@ -286,26 +287,26 @@ func TestContestRepository_DeleteContestTeam(t *testing.T) {
 	})
 
 	expected1 := []*domain.ContestTeam{&team1.ContestTeam, &team2.ContestTeam}
-	gotTeams1, err := repo.GetContestTeams(contest1.ID)
+	gotTeams1, err := repo.GetContestTeams(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, gotTeams1)
 
 	expected2 := []*domain.ContestTeam{}
-	gotTeams2, err := repo.GetContestTeams(contest2.ID)
+	gotTeams2, err := repo.GetContestTeams(context.Background(), contest2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, gotTeams2)
 
-	err = repo.DeleteContestTeam(contest1.ID, team1.ID)
+	err = repo.DeleteContestTeam(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	expected3 := []*domain.ContestTeam{&team2.ContestTeam}
-	gotTeams3, err := repo.GetContestTeams(contest1.ID)
+	gotTeams3, err := repo.GetContestTeams(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, expected3, gotTeams3)
 
-	err = repo.DeleteContestTeam(contest1.ID, team2.ID)
+	err = repo.DeleteContestTeam(context.Background(), contest1.ID, team2.ID)
 	assert.NoError(t, err)
 	expected4 := []*domain.ContestTeam{}
-	gotTeams4, err := repo.GetContestTeams(contest1.ID)
+	gotTeams4, err := repo.GetContestTeams(context.Background(), contest1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, expected4, gotTeams4)
 }
@@ -353,19 +354,19 @@ func TestContestRepository_GetContestTeamMembers(t *testing.T) {
 		domain.NewUser(user1.ID, user1.Name, portalUser1.RealName, user1.Check),
 		domain.NewUser(user2.ID, user2.Name, portalUser2.RealName, user2.Check),
 	}
-	users1, err := repo.GetContestTeamMembers(contest1.ID, team1.ID)
+	users1, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, users1)
 
 	expected2 := []*domain.User{
 		domain.NewUser(user2.ID, user2.Name, portalUser2.RealName, user2.Check),
 	}
-	users2, err := repo.GetContestTeamMembers(contest1.ID, team2.ID)
+	users2, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, users2)
 
 	expected3 := []*domain.User{}
-	users3, err := repo.GetContestTeamMembers(contest2.ID, team3.ID)
+	users3, err := repo.GetContestTeamMembers(context.Background(), contest2.ID, team3.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected3, users3)
 }
@@ -416,35 +417,35 @@ func TestContestRepository_EditContestTeamMembers(t *testing.T) {
 		domain.NewUser(user1.ID, user1.Name, portalUser1.RealName, user1.Check),
 		domain.NewUser(user2.ID, user2.Name, portalUser2.RealName, user2.Check),
 	}
-	users1, err := repo.GetContestTeamMembers(contest1.ID, team1.ID)
+	users1, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, users1)
 
 	expected2 := []*domain.User{
 		domain.NewUser(user2.ID, user2.Name, portalUser2.RealName, user2.Check),
 	}
-	users2, err := repo.GetContestTeamMembers(contest1.ID, team2.ID)
+	users2, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, users2)
 
 	expected3 := []*domain.User{}
-	users3, err := repo.GetContestTeamMembers(contest2.ID, team3.ID)
+	users3, err := repo.GetContestTeamMembers(context.Background(), contest2.ID, team3.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected3, users3)
 
 	expected4 := []*domain.User{
 		domain.NewUser(user2.ID, user2.Name, portalUser2.RealName, user2.Check),
 	}
-	err = repo.EditContestTeamMembers(team1.ID, []uuid.UUID{user2.ID})
+	err = repo.EditContestTeamMembers(context.Background(), team1.ID, []uuid.UUID{user2.ID})
 	assert.NoError(t, err)
-	users4, err := repo.GetContestTeamMembers(contest1.ID, team1.ID)
+	users4, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected4, users4)
 
 	expected5 := []*domain.User{}
-	err = repo.EditContestTeamMembers(team1.ID, []uuid.UUID{})
+	err = repo.EditContestTeamMembers(context.Background(), team1.ID, []uuid.UUID{})
 	assert.NoError(t, err)
-	users5, err := repo.GetContestTeamMembers(contest1.ID, team1.ID)
+	users5, err := repo.GetContestTeamMembers(context.Background(), contest1.ID, team1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected5, users5)
 }

--- a/integration_tests/repository/event_test.go
+++ b/integration_tests/repository/event_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 		})
 	}
 
-	got, err := repo.GetEvents()
+	got, err := repo.GetEvents(context.Background())
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, expected, got)
@@ -76,7 +77,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 		RoomID:      selected.RoomID,
 	}
 
-	got, err := repo.GetEvent(selected.ID)
+	got, err := repo.GetEvent(context.Background(), selected.ID)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expected, got)
@@ -103,17 +104,17 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 		break
 	}
 
-	got, err := repo.GetEvent(selected.EventID)
+	got, err := repo.GetEvent(context.Background(), selected.EventID)
 	assert.NoError(t, err)
 	assert.Equal(t, selected.Level, got.Level)
 
 	updatedLevel := random.Uint8n(uint8(domain.EventLevelLimit))
-	err = repo.UpdateEventLevel(selected.EventID, &urepository.UpdateEventLevelArgs{
+	err = repo.UpdateEventLevel(context.Background(), selected.EventID, &urepository.UpdateEventLevelArgs{
 		Level: optional.NewUint8(updatedLevel, true),
 	})
 	assert.NoError(t, err)
 
-	got, err = repo.GetEvent(selected.EventID)
+	got, err = repo.GetEvent(context.Background(), selected.EventID)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedLevel, uint8(got.Level))
 }
@@ -136,7 +137,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 		})
 	}
 
-	got, err := repo.GetEvents()
+	got, err := repo.GetEvents(context.Background())
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, expected, got)

--- a/integration_tests/repository/project_test.go
+++ b/integration_tests/repository/project_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -30,7 +31,7 @@ func TestProjectRepository_GetProjects(t *testing.T) {
 		projects = append(projects, mustMakeProject(t, repo, nil))
 	}
 
-	got, err := repo.GetProjects()
+	got, err := repo.GetProjects(context.Background())
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, projects, got)
@@ -52,7 +53,7 @@ func TestProjectRepository_GetProject(t *testing.T) {
 
 	opt := cmpopts.EquateEmpty()
 	for _, p := range projects {
-		got, err := repo.GetProject(p.ID)
+		got, err := repo.GetProject(context.Background(), p.ID)
 		assert.NoError(t, err)
 
 		if diff := cmp.Diff(p, got, opt); diff != "" {
@@ -103,10 +104,10 @@ func TestProjectRepository_UpdateProject(t *testing.T) {
 		project1.Duration.Until.Semester = int(arg1.UntilSemester.Int64)
 	}
 
-	err := repo.UpdateProject(project1.ID, &arg1)
+	err := repo.UpdateProject(context.Background(), project1.ID, &arg1)
 	assert.NoError(t, err)
 
-	got, err := repo.GetProject(project1.ID)
+	got, err := repo.GetProject(context.Background(), project1.ID)
 	assert.NoError(t, err)
 
 	opt := cmpopts.EquateEmpty()
@@ -171,7 +172,7 @@ func TestProjectRepository_GetProjectMembers(t *testing.T) {
 		},
 	}
 	expected1 := []*domain.UserWithDuration{projectMember1, projectMember2}
-	users1, err := repo.GetProjectMembers(project1.ID)
+	users1, err := repo.GetProjectMembers(context.Background(), project1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, users1)
 
@@ -190,7 +191,7 @@ func TestProjectRepository_GetProjectMembers(t *testing.T) {
 	}
 
 	expected2 := []*domain.UserWithDuration{projectMember3}
-	users2, err := repo.GetProjectMembers(project2.ID)
+	users2, err := repo.GetProjectMembers(context.Background(), project2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, users2)
 }
@@ -255,7 +256,7 @@ func TestProjectRepository_DeleteProjectMembers(t *testing.T) {
 		},
 	}
 	expected1 := []*domain.UserWithDuration{projectMember1, projectMember2}
-	users1, err := repo.GetProjectMembers(project1.ID)
+	users1, err := repo.GetProjectMembers(context.Background(), project1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, users1)
 
@@ -273,28 +274,28 @@ func TestProjectRepository_DeleteProjectMembers(t *testing.T) {
 		},
 	}
 	expected2 := []*domain.UserWithDuration{projectMember3}
-	users2, err := repo.GetProjectMembers(project2.ID)
+	users2, err := repo.GetProjectMembers(context.Background(), project2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, users2)
 
-	err = repo.DeleteProjectMembers(project1.ID, []uuid.UUID{projectMember1.User.ID})
+	err = repo.DeleteProjectMembers(context.Background(), project1.ID, []uuid.UUID{projectMember1.User.ID})
 	assert.NoError(t, err)
 	expected3 := []*domain.UserWithDuration{projectMember2}
-	users3, err := repo.GetProjectMembers(project1.ID)
+	users3, err := repo.GetProjectMembers(context.Background(), project1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected3, users3)
 
-	err = repo.DeleteProjectMembers(project1.ID, []uuid.UUID{projectMember2.User.ID})
+	err = repo.DeleteProjectMembers(context.Background(), project1.ID, []uuid.UUID{projectMember2.User.ID})
 	assert.NoError(t, err)
 	expected4 := []*domain.UserWithDuration{}
-	users4, err := repo.GetProjectMembers(project1.ID)
+	users4, err := repo.GetProjectMembers(context.Background(), project1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected4, users4)
 
-	err = repo.DeleteProjectMembers(project2.ID, []uuid.UUID{projectMember3.User.ID})
+	err = repo.DeleteProjectMembers(context.Background(), project2.ID, []uuid.UUID{projectMember3.User.ID})
 	assert.NoError(t, err)
 	expected5 := []*domain.UserWithDuration{}
-	users5, err := repo.GetProjectMembers(project2.ID)
+	users5, err := repo.GetProjectMembers(context.Background(), project2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected5, users5)
 }

--- a/integration_tests/repository/testutil_db_test.go
+++ b/integration_tests/repository/testutil_db_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -37,7 +38,7 @@ func mustMakeContest(t *testing.T, repo repository.ContestRepository, args *repo
 		}
 	}
 
-	contest, err := repo.CreateContest(args)
+	contest, err := repo.CreateContest(context.Background(), args)
 	assert.NoError(t, err)
 	return contest
 }
@@ -58,9 +59,9 @@ func mustMakeContestTeam(t *testing.T, repo repository.ContestRepository, contes
 	var contestTeamDetail *domain.ContestTeamDetail
 	if contestID == uuid.Nil {
 		contest := mustMakeContest(t, nil, nil)
-		contestTeamDetail, err = repo.CreateContestTeam(contest.ID, args)
+		contestTeamDetail, err = repo.CreateContestTeam(context.Background(), contest.ID, args)
 	} else {
-		contestTeamDetail, err = repo.CreateContestTeam(contestID, args)
+		contestTeamDetail, err = repo.CreateContestTeam(context.Background(), contestID, args)
 	}
 
 	assert.NoError(t, err)
@@ -78,7 +79,7 @@ func mustMakeEventLevel(t *testing.T, repo repository.EventRepository, args *rep
 		}
 	}
 
-	err := repo.CreateEventLevel(args)
+	err := repo.CreateEventLevel(context.Background(), args)
 	assert.NoError(t, err)
 
 	return args
@@ -100,7 +101,7 @@ func mustMakeAccount(t *testing.T, repo repository.UserRepository, userID uuid.U
 	if userID == uuid.Nil {
 		t.Fatal("userID must not be empty")
 	}
-	account, err := repo.CreateAccount(userID, args)
+	account, err := repo.CreateAccount(context.Background(), userID, args)
 	assert.NoError(t, err)
 
 	return account
@@ -129,7 +130,7 @@ func mustMakeProjectDetail(t *testing.T, repo repository.ProjectRepository, args
 		}
 	}
 
-	project, err := repo.CreateProject(args)
+	project, err := repo.CreateProject(context.Background(), args)
 	assert.NoError(t, err)
 
 	return project
@@ -152,7 +153,7 @@ func mustAddProjectMember(t *testing.T, repo repository.ProjectRepository, proje
 		}
 	}
 
-	err := repo.AddProjectMembers(projectID, []*repository.CreateProjectMemberArgs{args})
+	err := repo.AddProjectMembers(context.Background(), projectID, []*repository.CreateProjectMemberArgs{args})
 	assert.NoError(t, err)
 
 	return args
@@ -171,6 +172,6 @@ func mustAddContestTeamMembers(t *testing.T, repo repository.ContestRepository, 
 		t.Fatal("projectID must not be empty")
 	}
 
-	err := repo.AddContestTeamMembers(teamID, userIDs)
+	err := repo.AddContestTeamMembers(context.Background(), teamID, userIDs)
 	assert.NoError(t, err)
 }

--- a/integration_tests/repository/user_test.go
+++ b/integration_tests/repository/user_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestUserRepository_GetUsers(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			users, err := repo.GetUsers(tc.args.args)
+			users, err := repo.GetUsers(context.Background(), tc.args.args)
 			tc.assertion(t, err)
 			assert.ElementsMatch(t, tc.expected, users)
 		})
@@ -193,7 +194,7 @@ func TestUserRepository_GetUser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			users, err := repo.GetUser(tc.args.userID)
+			users, err := repo.GetUser(context.Background(), tc.args.userID)
 			tc.assertion(t, err)
 			assert.Equal(t, tc.expected, users)
 		})
@@ -246,7 +247,7 @@ func TestUserRepository_CreateUser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			user, err := repo.CreateUser(tc.args.args)
+			user, err := repo.CreateUser(context.Background(), tc.args.args)
 			tc.expected.ID = user.ID
 			tc.assertion(t, err)
 			assert.Equal(t, tc.expected, user)
@@ -273,7 +274,7 @@ func TestUserRepository_UpdateUser(t *testing.T) {
 		Check:       random.OptBool(),
 	}
 
-	err = repo.UpdateUser(user.ID, args)
+	err = repo.UpdateUser(context.Background(), user.ID, args)
 	assert.NoError(t, err)
 
 	var bio string
@@ -301,7 +302,7 @@ func TestUserRepository_UpdateUser(t *testing.T) {
 		Bio:      bio,
 		Accounts: []*domain.Account{},
 	}
-	got, err := repo.GetUser(user.ID)
+	got, err := repo.GetUser(context.Background(), user.ID)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expected, got)
@@ -323,7 +324,7 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 	account2 := mustMakeAccount(t, repo, user.ID, nil)
 	expected := []*domain.Account{account1, account2}
 
-	got, err := repo.GetAccounts(user.ID)
+	got, err := repo.GetAccounts(context.Background(), user.ID)
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, expected, got)
@@ -344,7 +345,7 @@ func TestUserRepository_GetAccount(t *testing.T) {
 	account1 := mustMakeAccount(t, repo, user.ID, nil)
 	mustMakeAccount(t, repo, user.ID, nil)
 
-	got, err := repo.GetAccount(user.ID, account1.ID)
+	got, err := repo.GetAccount(context.Background(), user.ID, account1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, account1, got)
 }
@@ -386,10 +387,10 @@ func TestUserRepository_UpdateAccount(t *testing.T) {
 	if args.PrPermitted.Valid {
 		account1.PrPermitted = args.PrPermitted.Bool
 	}
-	err = repo.UpdateAccount(user.ID, account1.ID, args)
+	err = repo.UpdateAccount(context.Background(), user.ID, account1.ID, args)
 	assert.NoError(t, err)
 
-	got, err := repo.GetAccount(user.ID, account1.ID)
+	got, err := repo.GetAccount(context.Background(), user.ID, account1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, account1, got)
 }
@@ -409,12 +410,12 @@ func TestUserRepository_DeleteAccount(t *testing.T) {
 	account1 := mustMakeAccount(t, repo, user.ID, nil)
 	account2 := mustMakeAccount(t, repo, user.ID, nil)
 
-	err = repo.DeleteAccount(user.ID, account1.ID)
+	err = repo.DeleteAccount(context.Background(), user.ID, account1.ID)
 	assert.NoError(t, err)
 
 	expected := []*domain.Account{account2}
 
-	got, err := repo.GetAccounts(user.ID)
+	got, err := repo.GetAccounts(context.Background(), user.ID)
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, expected, got)
@@ -437,9 +438,9 @@ func TestUserRepository_GetUserProjects(t *testing.T) {
 
 	expected1 := []*domain.UserWithDuration{}
 	expected2 := []*domain.UserWithDuration{}
-	users1, err := projectRepo.GetProjectMembers(project1.ID)
+	users1, err := projectRepo.GetProjectMembers(context.Background(), project1.ID)
 	assert.NoError(t, err)
-	users2, err := projectRepo.GetProjectMembers(project2.ID)
+	users2, err := projectRepo.GetProjectMembers(context.Background(), project2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, users1)
 	assert.ElementsMatch(t, expected2, users2)
@@ -448,7 +449,7 @@ func TestUserRepository_GetUserProjects(t *testing.T) {
 	args2 := mustAddProjectMember(t, projectRepo, project2.ID, user1.ID, nil)
 
 	expected3 := []*domain.UserProject{newUserProject(args1, project1), newUserProject(args2, project2)}
-	projects1, err := userRepo.GetProjects(user1.ID)
+	projects1, err := userRepo.GetProjects(context.Background(), user1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected3, projects1)
 }
@@ -487,12 +488,12 @@ func TestUserRepository_GetContests(t *testing.T) {
 	mustAddContestTeamMembers(t, contestRepo, team2.ID, []uuid.UUID{user1.ID})
 
 	expected1 := []*domain.UserContest{newUserContest(&contest1.Contest, []*domain.ContestTeam{&team1.ContestTeam}), newUserContest(&contest2.Contest, []*domain.ContestTeam{&team2.ContestTeam})}
-	contests1, err := userRepo.GetContests(user1.ID)
+	contests1, err := userRepo.GetContests(context.Background(), user1.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected1, contests1)
 
 	expected2 := []*domain.UserContest{newUserContest(&contest1.Contest, []*domain.ContestTeam{&team1.ContestTeam})}
-	contests2, err := userRepo.GetContests(user2.ID)
+	contests2, err := userRepo.GetContests(context.Background(), user2.ID)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected2, contests2)
 }

--- a/interfaces/database/mock_database/mock_sqlhandler.go
+++ b/interfaces/database/mock_database/mock_sqlhandler.go
@@ -1,6 +1,7 @@
 package mock_database //nolint:revive
 
 import (
+	"context"
 	"log"
 
 	"gorm.io/driver/mysql"
@@ -33,6 +34,11 @@ func NewMockSQLHandler() *MockSQLHandler {
 	}
 
 	return &MockSQLHandler{engine, mock}
+}
+
+func (h *MockSQLHandler) WithContext(ctx context.Context) database.SQLHandler {
+	db := h.Conn.WithContext(ctx)
+	return &MockSQLHandler{Conn: db}
 }
 
 func (h *MockSQLHandler) Find(out interface{}, where ...interface{}) database.SQLHandler {

--- a/interfaces/database/sqlhandler.go
+++ b/interfaces/database/sqlhandler.go
@@ -1,6 +1,9 @@
 package database
 
+import "context"
+
 type SQLHandler interface {
+	WithContext(ctx context.Context) SQLHandler
 	Find(out interface{}, where ...interface{}) SQLHandler
 	First(out interface{}, where ...interface{}) SQLHandler
 	Create(value interface{}) SQLHandler

--- a/interfaces/handler/user.go
+++ b/interfaces/handler/user.go
@@ -112,7 +112,8 @@ func (h *UserHandler) GetUserAccounts(_c echo.Context) error {
 		return convertError(err)
 	}
 
-	accounts, err := h.srv.GetAccounts(userID)
+	ctx := c.Request().Context()
+	accounts, err := h.srv.GetAccounts(ctx, userID)
 	if err != nil {
 		return convertError(err)
 	}
@@ -139,7 +140,8 @@ func (h *UserHandler) GetUserAccount(_c echo.Context) error {
 		return convertError(err)
 	}
 
-	account, err := h.srv.GetAccount(userID, accountID)
+	ctx := c.Request().Context()
+	account, err := h.srv.GetAccount(ctx, userID, accountID)
 	if err != nil {
 		return convertError(err)
 	}

--- a/interfaces/handler/user_test.go
+++ b/interfaces/handler/user_test.go
@@ -463,7 +463,7 @@ func TestUserHandler_GetUserAccounts(t *testing.T) {
 
 				}
 
-				s.EXPECT().GetAccounts(userID).Return(rAccounts, nil)
+				s.EXPECT().GetAccounts(anyCtx{}, userID).Return(rAccounts, nil)
 				path = fmt.Sprintf("/api/v1/users/%s/accounts", userID)
 				return hAccounts, path
 			},
@@ -474,7 +474,7 @@ func TestUserHandler_GetUserAccounts(t *testing.T) {
 			setup: func(s *mock_service.MockUserService) (hres []*Account, path string) {
 
 				userID := random.UUID()
-				s.EXPECT().GetAccounts(userID).Return(nil, errors.New("Internal Server Error"))
+				s.EXPECT().GetAccounts(anyCtx{}, userID).Return(nil, errors.New("Internal Server Error"))
 				path = fmt.Sprintf("/api/v1/users/%s/accounts", userID)
 				return nil, path
 			},
@@ -485,7 +485,7 @@ func TestUserHandler_GetUserAccounts(t *testing.T) {
 			setup: func(s *mock_service.MockUserService) (hres []*Account, path string) {
 
 				userID := random.UUID()
-				s.EXPECT().GetAccounts(userID).Return(nil, repository.ErrValidate)
+				s.EXPECT().GetAccounts(anyCtx{}, userID).Return(nil, repository.ErrValidate)
 				path = fmt.Sprintf("/api/v1/users/%s/accounts", userID)
 				return nil, path
 			},
@@ -550,7 +550,7 @@ func TestUserHandler_GetUserAccount(t *testing.T) {
 					Url:         rAccount.URL,
 				}
 
-				s.EXPECT().GetAccount(userID, rAccount.ID).Return(&rAccount, nil)
+				s.EXPECT().GetAccount(anyCtx{}, userID, rAccount.ID).Return(&rAccount, nil)
 				path = fmt.Sprintf("/api/v1/users/%s/accounts/%s", userID, rAccount.ID)
 				return &hAccount, path
 
@@ -564,7 +564,7 @@ func TestUserHandler_GetUserAccount(t *testing.T) {
 				userID := random.UUID()
 				accountID := random.UUID()
 
-				s.EXPECT().GetAccount(userID, accountID).Return(nil, errors.New("Internal Server Error"))
+				s.EXPECT().GetAccount(anyCtx{}, userID, accountID).Return(nil, errors.New("Internal Server Error"))
 				path = fmt.Sprintf("/api/v1/users/%s/accounts/%s", userID, accountID)
 				return nil, path
 

--- a/interfaces/repository/contest_impl.go
+++ b/interfaces/repository/contest_impl.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/interfaces/database"
@@ -18,9 +20,9 @@ func NewContestRepository(sql database.SQLHandler, portal external.PortalAPI) re
 	return &ContestRepository{h: sql, portal: portal}
 }
 
-func (r *ContestRepository) GetContests() ([]*domain.Contest, error) {
+func (r *ContestRepository) GetContests(ctx context.Context) ([]*domain.Contest, error) {
 	contests := make([]*model.Contest, 10)
-	err := r.h.Find(&contests).Error()
+	err := r.h.WithContext(ctx).Find(&contests).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -38,14 +40,14 @@ func (r *ContestRepository) GetContests() ([]*domain.Contest, error) {
 	return result, nil
 }
 
-func (r *ContestRepository) GetContest(contestID uuid.UUID) (*domain.ContestDetail, error) {
-	return r.getContest(contestID)
+func (r *ContestRepository) GetContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error) {
+	return r.getContest(ctx, contestID)
 }
 
 // Teamsは別途GetContestTeamsで取得するためここではnilのまま返す
-func (r *ContestRepository) getContest(contestID uuid.UUID) (*domain.ContestDetail, error) {
+func (r *ContestRepository) getContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error) {
 	contest := new(model.Contest)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(contest).
 		Error(); err != nil {
@@ -67,7 +69,7 @@ func (r *ContestRepository) getContest(contestID uuid.UUID) (*domain.ContestDeta
 	return res, nil
 }
 
-func (r *ContestRepository) CreateContest(args *repository.CreateContestArgs) (*domain.ContestDetail, error) {
+func (r *ContestRepository) CreateContest(ctx context.Context, args *repository.CreateContestArgs) (*domain.ContestDetail, error) {
 	contest := &model.Contest{
 		ID:          uuid.Must(uuid.NewV4()),
 		Name:        args.Name,
@@ -77,12 +79,12 @@ func (r *ContestRepository) CreateContest(args *repository.CreateContestArgs) (*
 		Until:       args.Until.ValueOrZero(),
 	}
 
-	err := r.h.Create(contest).Error()
+	err := r.h.WithContext(ctx).Create(contest).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
 
-	result, err := r.getContest(contest.ID)
+	result, err := r.getContest(ctx, contest.ID)
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -90,7 +92,7 @@ func (r *ContestRepository) CreateContest(args *repository.CreateContestArgs) (*
 	return result, nil
 }
 
-func (r *ContestRepository) UpdateContest(contestID uuid.UUID, args *repository.UpdateContestArgs) error {
+func (r *ContestRepository) UpdateContest(ctx context.Context, contestID uuid.UUID, args *repository.UpdateContestArgs) error {
 	changes := map[string]interface{}{}
 	if args.Name.Valid {
 		changes["name"] = args.Name.String
@@ -117,17 +119,17 @@ func (r *ContestRepository) UpdateContest(contestID uuid.UUID, args *repository.
 		new model.Contest
 	)
 
-	err := r.h.Transaction(func(tx database.SQLHandler) error {
-		if err := tx.
+	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
+		if err :=tx.WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&old).
 			Error(); err != nil {
 			return convertError(err)
 		}
-		if err := tx.Model(&old).Updates(changes).Error(); err != nil {
+		if err :=tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
 			return convertError(err)
 		}
-		err := tx.
+		err :=tx.WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&new).
 			Error()
@@ -140,16 +142,16 @@ func (r *ContestRepository) UpdateContest(contestID uuid.UUID, args *repository.
 	return nil
 }
 
-func (r *ContestRepository) DeleteContest(contestID uuid.UUID) error {
-	err := r.h.Transaction(func(tx database.SQLHandler) error {
-		if err := tx.
+func (r *ContestRepository) DeleteContest(ctx context.Context, contestID uuid.UUID) error {
+	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
+		if err :=tx.WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&model.Contest{}).
 			Error(); err != nil {
 			return convertError(err)
 		}
 
-		if err := tx.
+		if err :=tx.WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			Delete(&model.Contest{}).
 			Error(); err != nil {
@@ -165,8 +167,8 @@ func (r *ContestRepository) DeleteContest(contestID uuid.UUID) error {
 	return nil
 }
 
-func (r *ContestRepository) GetContestTeams(contestID uuid.UUID) ([]*domain.ContestTeam, error) {
-	if err := r.h.
+func (r *ContestRepository) GetContestTeams(ctx context.Context, contestID uuid.UUID) ([]*domain.ContestTeam, error) {
+	if err := r.h.WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(&model.Contest{}).
 		Error(); err != nil {
@@ -174,7 +176,7 @@ func (r *ContestRepository) GetContestTeams(contestID uuid.UUID) ([]*domain.Cont
 	}
 
 	teams := make([]*model.ContestTeam, 10)
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ContestID: contestID}).
 		Find(&teams).
 		Error()
@@ -194,9 +196,9 @@ func (r *ContestRepository) GetContestTeams(contestID uuid.UUID) ([]*domain.Cont
 }
 
 // Membersは別途GetContestTeamMembersで取得するためここではnilのまま返す
-func (r *ContestRepository) GetContestTeam(contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
+func (r *ContestRepository) GetContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
 	var team model.ContestTeam
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID, ContestID: contestID}).
 		First(&team).
 		Error(); err != nil {
@@ -217,7 +219,7 @@ func (r *ContestRepository) GetContestTeam(contestID uuid.UUID, teamID uuid.UUID
 	return res, nil
 }
 
-func (r *ContestRepository) CreateContestTeam(contestID uuid.UUID, _contestTeam *repository.CreateContestTeamArgs) (*domain.ContestTeamDetail, error) {
+func (r *ContestRepository) CreateContestTeam(ctx context.Context, contestID uuid.UUID, _contestTeam *repository.CreateContestTeamArgs) (*domain.ContestTeamDetail, error) {
 	contestTeam := &model.ContestTeam{
 		ID:          uuid.Must(uuid.NewV4()),
 		ContestID:   contestID,
@@ -227,7 +229,7 @@ func (r *ContestRepository) CreateContestTeam(contestID uuid.UUID, _contestTeam 
 		Link:        _contestTeam.Link.ValueOrZero(),
 	}
 
-	err := r.h.Create(contestTeam).Error()
+	err := r.h.WithContext(ctx).Create(contestTeam).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -245,7 +247,7 @@ func (r *ContestRepository) CreateContestTeam(contestID uuid.UUID, _contestTeam 
 	return result, nil
 }
 
-func (r *ContestRepository) UpdateContestTeam(teamID uuid.UUID, args *repository.UpdateContestTeamArgs) error {
+func (r *ContestRepository) UpdateContestTeam(ctx context.Context, teamID uuid.UUID, args *repository.UpdateContestTeamArgs) error {
 	changes := map[string]interface{}{}
 	if args.Name.Valid {
 		changes["name"] = args.Name.String
@@ -269,17 +271,17 @@ func (r *ContestRepository) UpdateContestTeam(teamID uuid.UUID, args *repository
 		new model.ContestTeam
 	)
 
-	err := r.h.Transaction(func(tx database.SQLHandler) error {
-		if err := tx.
+	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
+		if err :=tx.WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			First(&old).
 			Error(); err != nil {
 			return convertError(err)
 		}
-		if err := tx.Model(&old).Updates(changes).Error(); err != nil {
+		if err :=tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
 			return convertError(err)
 		}
-		err := tx.
+		err :=tx.WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			First(&new).
 			Error()
@@ -292,8 +294,8 @@ func (r *ContestRepository) UpdateContestTeam(teamID uuid.UUID, args *repository
 	return nil
 }
 
-func (r *ContestRepository) DeleteContestTeam(contestID uuid.UUID, teamID uuid.UUID) error {
-	err := r.h.
+func (r *ContestRepository) DeleteContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) error {
+	err := r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -301,8 +303,8 @@ func (r *ContestRepository) DeleteContestTeam(contestID uuid.UUID, teamID uuid.U
 		return convertError(err)
 	}
 
-	err = r.h.Transaction(func(tx database.SQLHandler) error {
-		err = tx.
+	err = r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
+		err =tx.WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			Delete(&model.ContestTeam{}).
 			Error()
@@ -319,16 +321,16 @@ func (r *ContestRepository) DeleteContestTeam(contestID uuid.UUID, teamID uuid.U
 	return nil
 }
 
-func (r *ContestRepository) GetContestTeamMembers(contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error) {
+func (r *ContestRepository) GetContestTeamMembers(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error) {
 	// 存在チェック
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(&model.Contest{}).
 		Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -337,7 +339,7 @@ func (r *ContestRepository) GetContestTeamMembers(contestID uuid.UUID, teamID uu
 	}
 
 	var belongings []*model.ContestTeamUserBelonging
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Preload("User").
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&belongings).
@@ -359,13 +361,13 @@ func (r *ContestRepository) GetContestTeamMembers(contestID uuid.UUID, teamID uu
 	return result, nil
 }
 
-func (r *ContestRepository) AddContestTeamMembers(teamID uuid.UUID, members []uuid.UUID) error {
+func (r *ContestRepository) AddContestTeamMembers(ctx context.Context, teamID uuid.UUID, members []uuid.UUID) error {
 	if len(members) == 0 {
 		return repository.ErrInvalidArg
 	}
 
 	// 存在チェック
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -376,7 +378,7 @@ func (r *ContestRepository) AddContestTeamMembers(teamID uuid.UUID, members []uu
 	// 既に所属しているメンバーを検索
 	belongingsMap := make(map[uuid.UUID]struct{}, len(members))
 	_belongings := make([]*model.ContestTeamUserBelonging, 0, len(members))
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&_belongings).
 		Error()
@@ -387,12 +389,12 @@ func (r *ContestRepository) AddContestTeamMembers(teamID uuid.UUID, members []uu
 		belongingsMap[v.UserID] = struct{}{}
 	}
 
-	err = r.h.Transaction(func(tx database.SQLHandler) error {
+	err = r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		for _, memberID := range members {
 			if _, ok := belongingsMap[memberID]; ok {
 				continue
 			}
-			err = tx.Create(&model.ContestTeamUserBelonging{TeamID: teamID, UserID: memberID}).Error()
+			err =tx.WithContext(ctx).Create(&model.ContestTeamUserBelonging{TeamID: teamID, UserID: memberID}).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -406,9 +408,9 @@ func (r *ContestRepository) AddContestTeamMembers(teamID uuid.UUID, members []uu
 
 }
 
-func (r *ContestRepository) EditContestTeamMembers(teamID uuid.UUID, members []uuid.UUID) error {
+func (r *ContestRepository) EditContestTeamMembers(ctx context.Context, teamID uuid.UUID, members []uuid.UUID) error {
 	// 存在チェック
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -418,7 +420,7 @@ func (r *ContestRepository) EditContestTeamMembers(teamID uuid.UUID, members []u
 
 	belongings := make(map[uuid.UUID]struct{}, len(members))
 	_belongings := make([]*model.ContestTeamUserBelonging, 0, len(members))
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&_belongings).
 		Error()
@@ -434,7 +436,7 @@ func (r *ContestRepository) EditContestTeamMembers(teamID uuid.UUID, members []u
 		membersMap[v] = struct{}{}
 	}
 
-	err = r.h.Transaction(func(tx database.SQLHandler) error {
+	err = r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		//チームに所属していなくて渡された配列に入っているメンバーをチームに追加
 		membersToBeAdded := make([]*model.ContestTeamUserBelonging, 0, len(members))
 		for _, memberID := range members {
@@ -443,7 +445,7 @@ func (r *ContestRepository) EditContestTeamMembers(teamID uuid.UUID, members []u
 			}
 		}
 		if len(membersToBeAdded) > 0 {
-			err = tx.Create(&membersToBeAdded).Error()
+			err =tx.WithContext(ctx).Create(&membersToBeAdded).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -456,7 +458,7 @@ func (r *ContestRepository) EditContestTeamMembers(teamID uuid.UUID, members []u
 			}
 		}
 		if len(membersToBeRemoved) > 0 {
-			err = tx.
+			err =tx.WithContext(ctx).
 				Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 				Where("`contest_team_user_belongings`.`user_id` IN (?)", membersToBeRemoved).
 				Delete(&model.ContestTeamUserBelonging{}).

--- a/interfaces/repository/contest_impl.go
+++ b/interfaces/repository/contest_impl.go
@@ -47,7 +47,8 @@ func (r *ContestRepository) GetContest(ctx context.Context, contestID uuid.UUID)
 // Teamsは別途GetContestTeamsで取得するためここではnilのまま返す
 func (r *ContestRepository) getContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error) {
 	contest := new(model.Contest)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(contest).
 		Error(); err != nil {
@@ -120,16 +121,18 @@ func (r *ContestRepository) UpdateContest(ctx context.Context, contestID uuid.UU
 	)
 
 	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
-		if err :=tx.WithContext(ctx).
+		if err := tx.
+			WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&old).
 			Error(); err != nil {
 			return convertError(err)
 		}
-		if err :=tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
+		if err := tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
 			return convertError(err)
 		}
-		err :=tx.WithContext(ctx).
+		err := tx.
+			WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&new).
 			Error()
@@ -144,14 +147,16 @@ func (r *ContestRepository) UpdateContest(ctx context.Context, contestID uuid.UU
 
 func (r *ContestRepository) DeleteContest(ctx context.Context, contestID uuid.UUID) error {
 	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
-		if err :=tx.WithContext(ctx).
+		if err := tx.
+			WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			First(&model.Contest{}).
 			Error(); err != nil {
 			return convertError(err)
 		}
 
-		if err :=tx.WithContext(ctx).
+		if err := tx.
+			WithContext(ctx).
 			Where(&model.Contest{ID: contestID}).
 			Delete(&model.Contest{}).
 			Error(); err != nil {
@@ -168,7 +173,8 @@ func (r *ContestRepository) DeleteContest(ctx context.Context, contestID uuid.UU
 }
 
 func (r *ContestRepository) GetContestTeams(ctx context.Context, contestID uuid.UUID) ([]*domain.ContestTeam, error) {
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(&model.Contest{}).
 		Error(); err != nil {
@@ -176,7 +182,8 @@ func (r *ContestRepository) GetContestTeams(ctx context.Context, contestID uuid.
 	}
 
 	teams := make([]*model.ContestTeam, 10)
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ContestID: contestID}).
 		Find(&teams).
 		Error()
@@ -198,7 +205,8 @@ func (r *ContestRepository) GetContestTeams(ctx context.Context, contestID uuid.
 // Membersは別途GetContestTeamMembersで取得するためここではnilのまま返す
 func (r *ContestRepository) GetContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
 	var team model.ContestTeam
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID, ContestID: contestID}).
 		First(&team).
 		Error(); err != nil {
@@ -272,16 +280,18 @@ func (r *ContestRepository) UpdateContestTeam(ctx context.Context, teamID uuid.U
 	)
 
 	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
-		if err :=tx.WithContext(ctx).
+		if err := tx.
+			WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			First(&old).
 			Error(); err != nil {
 			return convertError(err)
 		}
-		if err :=tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
+		if err := tx.WithContext(ctx).Model(&old).Updates(changes).Error(); err != nil {
 			return convertError(err)
 		}
-		err :=tx.WithContext(ctx).
+		err := tx.
+			WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			First(&new).
 			Error()
@@ -295,7 +305,8 @@ func (r *ContestRepository) UpdateContestTeam(ctx context.Context, teamID uuid.U
 }
 
 func (r *ContestRepository) DeleteContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) error {
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -304,7 +315,8 @@ func (r *ContestRepository) DeleteContestTeam(ctx context.Context, contestID uui
 	}
 
 	err = r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
-		err =tx.WithContext(ctx).
+		err = tx.
+			WithContext(ctx).
 			Where(&model.ContestTeam{ID: teamID}).
 			Delete(&model.ContestTeam{}).
 			Error()
@@ -323,14 +335,16 @@ func (r *ContestRepository) DeleteContestTeam(ctx context.Context, contestID uui
 
 func (r *ContestRepository) GetContestTeamMembers(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error) {
 	// 存在チェック
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.Contest{ID: contestID}).
 		First(&model.Contest{}).
 		Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -339,7 +353,8 @@ func (r *ContestRepository) GetContestTeamMembers(ctx context.Context, contestID
 	}
 
 	var belongings []*model.ContestTeamUserBelonging
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Preload("User").
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&belongings).
@@ -367,7 +382,8 @@ func (r *ContestRepository) AddContestTeamMembers(ctx context.Context, teamID uu
 	}
 
 	// 存在チェック
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -378,7 +394,8 @@ func (r *ContestRepository) AddContestTeamMembers(ctx context.Context, teamID uu
 	// 既に所属しているメンバーを検索
 	belongingsMap := make(map[uuid.UUID]struct{}, len(members))
 	_belongings := make([]*model.ContestTeamUserBelonging, 0, len(members))
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&_belongings).
 		Error()
@@ -394,7 +411,7 @@ func (r *ContestRepository) AddContestTeamMembers(ctx context.Context, teamID uu
 			if _, ok := belongingsMap[memberID]; ok {
 				continue
 			}
-			err =tx.WithContext(ctx).Create(&model.ContestTeamUserBelonging{TeamID: teamID, UserID: memberID}).Error()
+			err = tx.WithContext(ctx).Create(&model.ContestTeamUserBelonging{TeamID: teamID, UserID: memberID}).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -410,7 +427,8 @@ func (r *ContestRepository) AddContestTeamMembers(ctx context.Context, teamID uu
 
 func (r *ContestRepository) EditContestTeamMembers(ctx context.Context, teamID uuid.UUID, members []uuid.UUID) error {
 	// 存在チェック
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeam{ID: teamID}).
 		First(&model.ContestTeam{}).
 		Error()
@@ -420,7 +438,8 @@ func (r *ContestRepository) EditContestTeamMembers(ctx context.Context, teamID u
 
 	belongings := make(map[uuid.UUID]struct{}, len(members))
 	_belongings := make([]*model.ContestTeamUserBelonging, 0, len(members))
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 		Find(&_belongings).
 		Error()
@@ -445,7 +464,7 @@ func (r *ContestRepository) EditContestTeamMembers(ctx context.Context, teamID u
 			}
 		}
 		if len(membersToBeAdded) > 0 {
-			err =tx.WithContext(ctx).Create(&membersToBeAdded).Error()
+			err = tx.WithContext(ctx).Create(&membersToBeAdded).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -458,7 +477,8 @@ func (r *ContestRepository) EditContestTeamMembers(ctx context.Context, teamID u
 			}
 		}
 		if len(membersToBeRemoved) > 0 {
-			err =tx.WithContext(ctx).
+			err = tx.
+				WithContext(ctx).
 				Where(&model.ContestTeamUserBelonging{TeamID: teamID}).
 				Where("`contest_team_user_belongings`.`user_id` IN (?)", membersToBeRemoved).
 				Delete(&model.ContestTeamUserBelonging{}).

--- a/interfaces/repository/contest_impl_test.go
+++ b/interfaces/repository/contest_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql/driver"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func TestContestRepository_GetContests(t *testing.T) {
 			tt.setup(f, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetContests()
+			got, err := repo.GetContests(context.Background())
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -154,7 +155,7 @@ func TestContestRepository_GetContest(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetContest(tt.args.id)
+			got, err := repo.GetContest(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -273,7 +274,7 @@ func TestContestRepository_CreateContest(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.CreateContest(tt.args.args)
+			got, err := repo.CreateContest(context.Background(), tt.args.args)
 			if tt.want != nil && got != nil {
 				tt.want.ID = got.ID // 関数内でIDを生成するためここで合わせる
 			}
@@ -394,7 +395,7 @@ func TestContestRepository_UpdateContest(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.UpdateContest(tt.args.id, tt.args.args))
+			tt.assertion(t, repo.UpdateContest(context.Background(), tt.args.id, tt.args.args))
 		})
 	}
 }
@@ -480,7 +481,7 @@ func TestContestRepository_DeleteContest(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.DeleteContest(tt.args.id))
+			tt.assertion(t, repo.DeleteContest(context.Background(), tt.args.id))
 		})
 	}
 }
@@ -571,7 +572,7 @@ func TestContestRepository_GetContestTeams(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetContestTeams(tt.args.contestID)
+			got, err := repo.GetContestTeams(context.Background(), tt.args.contestID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -648,7 +649,7 @@ func TestContestRepository_GetContestTeam(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetContestTeam(tt.args.contestID, tt.args.teamID)
+			got, err := repo.GetContestTeam(context.Background(), tt.args.contestID, tt.args.teamID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -736,7 +737,7 @@ func TestContestRepository_CreateContestTeam(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.CreateContestTeam(tt.args.contestID, tt.args._contestTeam)
+			got, err := repo.CreateContestTeam(context.Background(), tt.args.contestID, tt.args._contestTeam)
 			if tt.want != nil && got != nil {
 				tt.want.ID = got.ID // 関数内でIDを生成するためここで合わせる
 			}
@@ -854,7 +855,7 @@ func TestContestRepository_UpdateContestTeam(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.UpdateContestTeam(tt.args.teamID, tt.args.args))
+			tt.assertion(t, repo.UpdateContestTeam(context.Background(), tt.args.teamID, tt.args.args))
 		})
 	}
 }
@@ -1080,7 +1081,7 @@ func TestContestRepository_GetContestTeamMembers(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetContestTeamMembers(tt.args.contestID, tt.args.teamID)
+			got, err := repo.GetContestTeamMembers(context.Background(), tt.args.contestID, tt.args.teamID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -1225,7 +1226,7 @@ func TestContestRepository_AddContestTeamMembers(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.AddContestTeamMembers(tt.args.teamID, tt.args.members))
+			tt.assertion(t, repo.AddContestTeamMembers(context.Background(), tt.args.teamID, tt.args.members))
 		})
 	}
 }
@@ -1407,7 +1408,7 @@ func TestContestRepository_EditContestTeamMembers(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewContestRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.EditContestTeamMembers(tt.args.teamID, tt.args.members))
+			tt.assertion(t, repo.EditContestTeamMembers(context.Background(), tt.args.teamID, tt.args.members))
 		})
 	}
 }

--- a/interfaces/repository/event_impl.go
+++ b/interfaces/repository/event_impl.go
@@ -111,7 +111,7 @@ func (r *EventRepository) UpdateEventLevel(ctx context.Context, eventID uuid.UUI
 			return nil // updateする必要がないのでここでcommitする
 		}
 
-		if err :=tx.WithContext(ctx).Model(&model.EventLevelRelation{ID: eventID}).Update("level", arg.Level).Error(); err != nil {
+		if err := tx.WithContext(ctx).Model(&model.EventLevelRelation{ID: eventID}).Update("level", arg.Level).Error(); err != nil {
 			return convertError(err)
 		}
 
@@ -145,7 +145,8 @@ func (r *EventRepository) GetUserEvents(ctx context.Context, userID uuid.UUID) (
 
 func (r *EventRepository) getEventLevelByID(ctx context.Context, eventID uuid.UUID) (*model.EventLevelRelation, error) {
 	elv := &model.EventLevelRelation{}
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.EventLevelRelation{ID: eventID}).
 		First(elv).
 		Error()

--- a/interfaces/repository/event_impl_test.go
+++ b/interfaces/repository/event_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestEventRepository_GetEvents(t *testing.T) {
 			tt.setup(f, tt.want)
 			repo := NewEventRepository(f.h, f.knoq)
 			// Assertion
-			got, err := repo.GetEvents()
+			got, err := repo.GetEvents(context.Background())
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -212,7 +213,7 @@ func TestEventRepository_GetEvent(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewEventRepository(f.h, f.knoq)
 			// Assertion
-			got, err := repo.GetEvent(tt.args.id)
+			got, err := repo.GetEvent(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -315,7 +316,7 @@ func TestEventRepository_CreateEventLevel(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewEventRepository(f.h, f.knoq)
 			// Assertion
-			err := repo.CreateEventLevel(tt.args.args)
+			err := repo.CreateEventLevel(context.Background(), tt.args.args)
 			tt.assertion(t, err)
 		})
 	}
@@ -427,7 +428,7 @@ func TestEventRepository_UpdateEventLevel(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewEventRepository(f.h, f.knoq)
 			// Assertion
-			tt.assertion(t, repo.UpdateEventLevel(tt.args.id, tt.args.arg))
+			tt.assertion(t, repo.UpdateEventLevel(context.Background(), tt.args.id, tt.args.arg))
 		})
 	}
 }
@@ -492,7 +493,7 @@ func TestEventRepository_GetUserEvents(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewEventRepository(f.h, f.knoq)
 			// Assertion
-			got, err := repo.GetUserEvents(tt.args.userID)
+			got, err := repo.GetUserEvents(context.Background(), tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/interfaces/repository/group_impl.go
+++ b/interfaces/repository/group_impl.go
@@ -37,7 +37,8 @@ func (r *GroupRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, er
 
 func (r *GroupRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.GroupDetail, error) {
 	group := &model.Group{}
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.Group{GroupID: groupID}).
 		First(group).
 		Error(); err != nil {
@@ -45,7 +46,8 @@ func (r *GroupRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*dom
 	}
 
 	users := make([]*model.GroupUserBelonging, 0)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.GroupUserBelonging{GroupID: groupID}).
 		Find(&users).
 		Error(); err != nil {
@@ -75,7 +77,8 @@ func (r *GroupRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*dom
 	}
 
 	admins := make([]*model.GroupUserAdmin, 0)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.GroupUserAdmin{GroupID: groupID}).
 		Find(&admins).
 		Error(); err != nil {

--- a/interfaces/repository/group_impl.go
+++ b/interfaces/repository/group_impl.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/interfaces/database"
@@ -16,9 +18,9 @@ func NewGroupRepository(sql database.SQLHandler) repository.GroupRepository {
 	return &GroupRepository{h: sql}
 }
 
-func (r *GroupRepository) GetAllGroups() ([]*domain.Group, error) {
+func (r *GroupRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
 	groups := make([]*model.Group, 0)
-	err := r.h.Find(&groups).Error()
+	err := r.h.WithContext(ctx).Find(&groups).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -33,9 +35,9 @@ func (r *GroupRepository) GetAllGroups() ([]*domain.Group, error) {
 	return result, nil
 }
 
-func (r *GroupRepository) GetGroup(groupID uuid.UUID) (*domain.GroupDetail, error) {
+func (r *GroupRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.GroupDetail, error) {
 	group := &model.Group{}
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.Group{GroupID: groupID}).
 		First(group).
 		Error(); err != nil {
@@ -43,7 +45,7 @@ func (r *GroupRepository) GetGroup(groupID uuid.UUID) (*domain.GroupDetail, erro
 	}
 
 	users := make([]*model.GroupUserBelonging, 0)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.GroupUserBelonging{GroupID: groupID}).
 		Find(&users).
 		Error(); err != nil {
@@ -73,7 +75,7 @@ func (r *GroupRepository) GetGroup(groupID uuid.UUID) (*domain.GroupDetail, erro
 	}
 
 	admins := make([]*model.GroupUserAdmin, 0)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.GroupUserAdmin{GroupID: groupID}).
 		Find(&admins).
 		Error(); err != nil {

--- a/interfaces/repository/group_impl_test.go
+++ b/interfaces/repository/group_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -66,7 +67,7 @@ func TestGroupRepository_GetAllGroups(t *testing.T) {
 			f := newMockGroupRepositoryFields()
 			tt.setup(f, tt.want)
 			repo := NewGroupRepository(f.h)
-			got, err := repo.GetAllGroups()
+			got, err := repo.GetAllGroups(context.Background())
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -234,7 +235,7 @@ func TestGroupRepository_GetGroup(t *testing.T) {
 			f := newMockGroupRepositoryFields()
 			tt.setup(f, tt.args, tt.want)
 			repo := NewGroupRepository(f.h)
-			got, err := repo.GetGroup(tt.args.id)
+			got, err := repo.GetGroup(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/interfaces/repository/project_impl.go
+++ b/interfaces/repository/project_impl.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/interfaces/database"
@@ -19,9 +21,9 @@ func NewProjectRepository(h database.SQLHandler, portal external.PortalAPI) repo
 	return &ProjectRepository{h, portal}
 }
 
-func (r *ProjectRepository) GetProjects() ([]*domain.Project, error) {
+func (r *ProjectRepository) GetProjects(ctx context.Context) ([]*domain.Project, error) {
 	projects := make([]*model.Project, 0)
-	err := r.h.Find(&projects).Error()
+	err := r.h.WithContext(ctx).Find(&projects).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -37,9 +39,9 @@ func (r *ProjectRepository) GetProjects() ([]*domain.Project, error) {
 	return res, nil
 }
 
-func (r *ProjectRepository) GetProject(projectID uuid.UUID) (*domain.ProjectDetail, error) {
+func (r *ProjectRepository) GetProject(ctx context.Context, projectID uuid.UUID) (*domain.ProjectDetail, error) {
 	project := new(model.Project)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(project).
 		Error(); err != nil {
@@ -47,7 +49,7 @@ func (r *ProjectRepository) GetProject(projectID uuid.UUID) (*domain.ProjectDeta
 	}
 
 	members := make([]*model.ProjectMember, 0)
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Preload("User").
 		Where(model.ProjectMember{ProjectID: projectID}).
 		Find(&members).
@@ -95,7 +97,7 @@ func (r *ProjectRepository) GetProject(projectID uuid.UUID) (*domain.ProjectDeta
 	return res, nil
 }
 
-func (r *ProjectRepository) CreateProject(args *repository.CreateProjectArgs) (*domain.ProjectDetail, error) {
+func (r *ProjectRepository) CreateProject(ctx context.Context, args *repository.CreateProjectArgs) (*domain.ProjectDetail, error) {
 	p := model.Project{
 		ID:            random.UUID(),
 		Name:          args.Name,
@@ -109,7 +111,7 @@ func (r *ProjectRepository) CreateProject(args *repository.CreateProjectArgs) (*
 		p.Link = args.Link.String
 	}
 
-	err := r.h.Create(&p).Error()
+	err := r.h.WithContext(ctx).Create(&p).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -127,7 +129,7 @@ func (r *ProjectRepository) CreateProject(args *repository.CreateProjectArgs) (*
 	return res, nil
 }
 
-func (r *ProjectRepository) UpdateProject(projectID uuid.UUID, args *repository.UpdateProjectArgs) error {
+func (r *ProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UUID, args *repository.UpdateProjectArgs) error {
 	changes := map[string]interface{}{}
 	if args.Name.Valid {
 		changes["name"] = args.Name.String
@@ -151,7 +153,7 @@ func (r *ProjectRepository) UpdateProject(projectID uuid.UUID, args *repository.
 		return nil
 	}
 
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Model(&model.Project{}).
 		Where(&model.Project{ID: projectID}).
 		Updates(changes).
@@ -163,9 +165,9 @@ func (r *ProjectRepository) UpdateProject(projectID uuid.UUID, args *repository.
 	return nil
 }
 
-func (r *ProjectRepository) GetProjectMembers(projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
+func (r *ProjectRepository) GetProjectMembers(ctx context.Context, projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
 	members := make([]*model.ProjectMember, 0)
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Preload("User").
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Find(&members).
@@ -203,7 +205,7 @@ func (r *ProjectRepository) GetProjectMembers(projectID uuid.UUID) ([]*domain.Us
 	return res, nil
 }
 
-func (r *ProjectRepository) AddProjectMembers(projectID uuid.UUID, projectMembers []*repository.CreateProjectMemberArgs) error {
+func (r *ProjectRepository) AddProjectMembers(ctx context.Context, projectID uuid.UUID, projectMembers []*repository.CreateProjectMemberArgs) error {
 	if len(projectMembers) == 0 {
 		return repository.ErrInvalidArg
 	}
@@ -218,7 +220,7 @@ func (r *ProjectRepository) AddProjectMembers(projectID uuid.UUID, projectMember
 	}
 
 	// プロジェクトの存在チェック
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(&model.Project{}).
 		Error()
@@ -228,7 +230,7 @@ func (r *ProjectRepository) AddProjectMembers(projectID uuid.UUID, projectMember
 
 	mmbsMp := make(map[uuid.UUID]struct{}, len(projectMembers))
 	_mmbs := make([]*model.ProjectMember, 0, len(projectMembers))
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Find(&_mmbs).
 		Error()
@@ -254,12 +256,12 @@ func (r *ProjectRepository) AddProjectMembers(projectID uuid.UUID, projectMember
 		members = append(members, m)
 	}
 
-	err = r.h.Transaction(func(tx database.SQLHandler) error {
+	err = r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		for _, v := range members {
 			if _, ok := mmbsMp[v.UserID]; ok {
 				continue
 			}
-			err = tx.Create(v).Error()
+			err =tx.WithContext(ctx).Create(v).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -273,13 +275,13 @@ func (r *ProjectRepository) AddProjectMembers(projectID uuid.UUID, projectMember
 	return nil
 }
 
-func (r *ProjectRepository) DeleteProjectMembers(projectID uuid.UUID, members []uuid.UUID) error {
+func (r *ProjectRepository) DeleteProjectMembers(ctx context.Context, projectID uuid.UUID, members []uuid.UUID) error {
 	if len(members) == 0 {
 		return repository.ErrInvalidArg
 	}
 
 	// プロジェクトの存在チェック
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(&model.Project{}).
 		Error()
@@ -287,7 +289,7 @@ func (r *ProjectRepository) DeleteProjectMembers(projectID uuid.UUID, members []
 		return convertError(err)
 	}
 
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Where("`project_members`.`user_id` IN (?)", members).
 		Delete(&model.ProjectMember{}).

--- a/interfaces/repository/project_impl.go
+++ b/interfaces/repository/project_impl.go
@@ -41,7 +41,8 @@ func (r *ProjectRepository) GetProjects(ctx context.Context) ([]*domain.Project,
 
 func (r *ProjectRepository) GetProject(ctx context.Context, projectID uuid.UUID) (*domain.ProjectDetail, error) {
 	project := new(model.Project)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(project).
 		Error(); err != nil {
@@ -49,7 +50,8 @@ func (r *ProjectRepository) GetProject(ctx context.Context, projectID uuid.UUID)
 	}
 
 	members := make([]*model.ProjectMember, 0)
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Preload("User").
 		Where(model.ProjectMember{ProjectID: projectID}).
 		Find(&members).
@@ -153,7 +155,8 @@ func (r *ProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UU
 		return nil
 	}
 
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Model(&model.Project{}).
 		Where(&model.Project{ID: projectID}).
 		Updates(changes).
@@ -167,7 +170,8 @@ func (r *ProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UU
 
 func (r *ProjectRepository) GetProjectMembers(ctx context.Context, projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
 	members := make([]*model.ProjectMember, 0)
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Preload("User").
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Find(&members).
@@ -220,7 +224,8 @@ func (r *ProjectRepository) AddProjectMembers(ctx context.Context, projectID uui
 	}
 
 	// プロジェクトの存在チェック
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(&model.Project{}).
 		Error()
@@ -230,7 +235,8 @@ func (r *ProjectRepository) AddProjectMembers(ctx context.Context, projectID uui
 
 	mmbsMp := make(map[uuid.UUID]struct{}, len(projectMembers))
 	_mmbs := make([]*model.ProjectMember, 0, len(projectMembers))
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Find(&_mmbs).
 		Error()
@@ -261,7 +267,7 @@ func (r *ProjectRepository) AddProjectMembers(ctx context.Context, projectID uui
 			if _, ok := mmbsMp[v.UserID]; ok {
 				continue
 			}
-			err =tx.WithContext(ctx).Create(v).Error()
+			err = tx.WithContext(ctx).Create(v).Error()
 			if err != nil {
 				return convertError(err)
 			}
@@ -281,7 +287,8 @@ func (r *ProjectRepository) DeleteProjectMembers(ctx context.Context, projectID 
 	}
 
 	// プロジェクトの存在チェック
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.Project{ID: projectID}).
 		First(&model.Project{}).
 		Error()
@@ -289,7 +296,8 @@ func (r *ProjectRepository) DeleteProjectMembers(ctx context.Context, projectID 
 		return convertError(err)
 	}
 
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.ProjectMember{ProjectID: projectID}).
 		Where("`project_members`.`user_id` IN (?)", members).
 		Delete(&model.ProjectMember{}).

--- a/interfaces/repository/project_impl_test.go
+++ b/interfaces/repository/project_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql/driver"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestProjectRepository_GetProjects(t *testing.T) {
 			tt.setup(f, tt.want)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetProjects()
+			got, err := repo.GetProjects(context.Background())
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -327,7 +328,7 @@ func TestProjectRepository_GetProject(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetProject(tt.args.id)
+			got, err := repo.GetProject(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -427,7 +428,7 @@ func TestProjectRepository_CreateProject(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.CreateProject(tt.args.project)
+			got, err := repo.CreateProject(context.Background(), tt.args.project)
 			if tt.want != nil && got != nil {
 				tt.want.ID = got.ID // 関数内でIDを生成するためここで合わせる
 			}
@@ -510,7 +511,7 @@ func TestProjectRepository_UpdateProject(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.UpdateProject(tt.args.id, tt.args.args))
+			tt.assertion(t, repo.UpdateProject(context.Background(), tt.args.id, tt.args.args))
 		})
 	}
 }
@@ -666,7 +667,7 @@ func TestProjectRepository_GetProjectMembers(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			got, err := repo.GetProjectMembers(tt.args.id)
+			got, err := repo.GetProjectMembers(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -910,7 +911,7 @@ func TestProjectRepository_AddProjectMembers(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.AddProjectMembers(tt.args.projectID, tt.args.projectMembers))
+			tt.assertion(t, repo.AddProjectMembers(context.Background(), tt.args.projectID, tt.args.projectMembers))
 		})
 	}
 }
@@ -1016,7 +1017,7 @@ func TestProjectRepository_DeleteProjectMembers(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewProjectRepository(f.h, f.portal)
 			// Assertion
-			tt.assertion(t, repo.DeleteProjectMembers(tt.args.projectID, tt.args.members))
+			tt.assertion(t, repo.DeleteProjectMembers(context.Background(), tt.args.projectID, tt.args.members))
 		})
 	}
 }

--- a/interfaces/repository/user_impl.go
+++ b/interfaces/repository/user_impl.go
@@ -63,7 +63,8 @@ func (r *UserRepository) GetUsers(ctx context.Context, args *repository.GetUsers
 	}
 
 	users := make([]*model.User, 0)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where("`users`.`id` IN (?)", traqUserIDs).
 		Limit(limit).
 		Find(&users).
@@ -116,7 +117,8 @@ func (r *UserRepository) GetUsers(ctx context.Context, args *repository.GetUsers
 
 func (r *UserRepository) GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error) {
 	user := new(model.User)
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Preload("Accounts").
 		Where(&model.User{ID: userID}).
 		First(user).
@@ -208,15 +210,15 @@ func (r *UserRepository) UpdateUser(ctx context.Context, userID uuid.UUID, args 
 
 	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		user := new(model.User)
-		err :=tx.WithContext(ctx).
-			Where(&model.User{ID: userID}).
+		err := tx.
+			WithContext(ctx).Where(&model.User{ID: userID}).
 			First(user).
 			Error()
 		if err != nil {
 			return convertError(err)
 		}
 
-		err =tx.WithContext(ctx).Model(user).Updates(changes).Error()
+		err = tx.WithContext(ctx).Model(user).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -230,7 +232,8 @@ func (r *UserRepository) UpdateUser(ctx context.Context, userID uuid.UUID, args 
 }
 
 func (r *UserRepository) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error) {
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -239,7 +242,8 @@ func (r *UserRepository) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*
 	}
 
 	accounts := make([]*model.Account, 0)
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Where(&model.Account{UserID: userID}).
 		Find(&accounts).
 		Error()
@@ -262,7 +266,8 @@ func (r *UserRepository) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*
 
 func (r *UserRepository) GetAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
 	account := &model.Account{}
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.Account{ID: accountID, UserID: userID}).
 		First(account).
 		Error()
@@ -300,7 +305,8 @@ func (r *UserRepository) CreateAccount(ctx context.Context, userID uuid.UUID, ar
 	}
 
 	ver := new(model.Account)
-	if err := r.h.WithContext(ctx).
+	if err := r.h.
+		WithContext(ctx).
 		Where(&model.Account{ID: account.ID}).
 		First(ver).
 		Error(); err != nil {
@@ -337,8 +343,8 @@ func (r *UserRepository) UpdateAccount(ctx context.Context, userID uuid.UUID, ac
 
 	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		account := new(model.Account)
-		err :=tx.WithContext(ctx).
-			Where(&model.Account{ID: accountID, UserID: userID}).
+		err := tx.
+			WithContext(ctx).Where(&model.Account{ID: accountID, UserID: userID}).
 			First(account).
 			Error()
 		if err != nil {
@@ -360,7 +366,7 @@ func (r *UserRepository) UpdateAccount(ctx context.Context, userID uuid.UUID, ac
 			}
 		}
 
-		err =tx.WithContext(ctx).Model(account).Updates(changes).Error()
+		err = tx.WithContext(ctx).Model(account).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -371,15 +377,15 @@ func (r *UserRepository) UpdateAccount(ctx context.Context, userID uuid.UUID, ac
 
 func (r *UserRepository) DeleteAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) error {
 	if err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
-		if err :=tx.WithContext(ctx).
-			Where(&model.Account{ID: accountID, UserID: userID}).
+		if err := tx.
+			WithContext(ctx).Where(&model.Account{ID: accountID, UserID: userID}).
 			First(&model.Account{}).
 			Error(); err != nil {
 			return convertError(err)
 		}
 
-		if err :=tx.WithContext(ctx).
-			Where(&model.Account{ID: accountID, UserID: userID}).
+		if err := tx.
+			WithContext(ctx).Where(&model.Account{ID: accountID, UserID: userID}).
 			Delete(&model.Account{}).
 			Error(); err != nil {
 			return convertError(err)
@@ -394,7 +400,8 @@ func (r *UserRepository) DeleteAccount(ctx context.Context, userID uuid.UUID, ac
 }
 
 func (r *UserRepository) GetProjects(ctx context.Context, userID uuid.UUID) ([]*domain.UserProject, error) {
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -403,7 +410,8 @@ func (r *UserRepository) GetProjects(ctx context.Context, userID uuid.UUID) ([]*
 	}
 
 	projects := make([]*model.ProjectMember, 0)
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Preload("Project").
 		Where(&model.ProjectMember{UserID: userID}).
 		Find(&projects).
@@ -426,7 +434,8 @@ func (r *UserRepository) GetProjects(ctx context.Context, userID uuid.UUID) ([]*
 }
 
 func (r *UserRepository) GetGroupsByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.UserGroup, error) {
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -435,7 +444,8 @@ func (r *UserRepository) GetGroupsByUserID(ctx context.Context, userID uuid.UUID
 	}
 
 	groups := make([]*model.GroupUserBelonging, 0)
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Preload("Group").
 		Where(&model.GroupUserBelonging{UserID: userID}).
 		Find(&groups).
@@ -466,7 +476,8 @@ func (r *UserRepository) GetGroupsByUserID(ctx context.Context, userID uuid.UUID
 }
 
 func (r *UserRepository) GetContests(ctx context.Context, userID uuid.UUID) ([]*domain.UserContest, error) {
-	err := r.h.WithContext(ctx).
+	err := r.h.
+		WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -475,7 +486,8 @@ func (r *UserRepository) GetContests(ctx context.Context, userID uuid.UUID) ([]*
 	}
 
 	contestTeamUserBelongings := make([]*model.ContestTeamUserBelonging, 0)
-	err = r.h.WithContext(ctx).
+	err = r.h.
+		WithContext(ctx).
 		Preload("ContestTeam.Contest").
 		Where(&model.ContestTeamUserBelonging{UserID: userID}).
 		Find(&contestTeamUserBelongings).

--- a/interfaces/repository/user_impl.go
+++ b/interfaces/repository/user_impl.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/interfaces/database"
@@ -37,7 +39,7 @@ func makeTraqGetAllArgs(rargs *repository.GetUsersArgs) (*external.TraQGetAllArg
 	return eargs, nil
 }
 
-func (r *UserRepository) GetUsers(args *repository.GetUsersArgs) ([]*domain.User, error) {
+func (r *UserRepository) GetUsers(ctx context.Context, args *repository.GetUsersArgs) ([]*domain.User, error) {
 	eargs, err := makeTraqGetAllArgs(args)
 
 	limit := -1
@@ -61,7 +63,7 @@ func (r *UserRepository) GetUsers(args *repository.GetUsersArgs) ([]*domain.User
 	}
 
 	users := make([]*model.User, 0)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where("`users`.`id` IN (?)", traqUserIDs).
 		Limit(limit).
 		Find(&users).
@@ -112,9 +114,9 @@ func (r *UserRepository) GetUsers(args *repository.GetUsersArgs) ([]*domain.User
 	}
 }
 
-func (r *UserRepository) GetUser(userID uuid.UUID) (*domain.UserDetail, error) {
+func (r *UserRepository) GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error) {
 	user := new(model.User)
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Preload("Accounts").
 		Where(&model.User{ID: userID}).
 		First(user).
@@ -159,7 +161,7 @@ func (r *UserRepository) GetUser(userID uuid.UUID) (*domain.UserDetail, error) {
 	return &result, nil
 }
 
-func (r *UserRepository) CreateUser(args *repository.CreateUserArgs) (*domain.UserDetail, error) {
+func (r *UserRepository) CreateUser(ctx context.Context, args *repository.CreateUserArgs) (*domain.UserDetail, error) {
 	portalUser, err := r.portal.GetByTraqID(args.Name)
 	if err != nil {
 		return nil, err
@@ -172,7 +174,7 @@ func (r *UserRepository) CreateUser(args *repository.CreateUserArgs) (*domain.Us
 		Name:        args.Name,
 	}
 
-	err = r.h.Create(&user).Error()
+	err = r.h.WithContext(ctx).Create(&user).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
@@ -191,7 +193,7 @@ func (r *UserRepository) CreateUser(args *repository.CreateUserArgs) (*domain.Us
 	return result, nil
 }
 
-func (r *UserRepository) UpdateUser(userID uuid.UUID, args *repository.UpdateUserArgs) error {
+func (r *UserRepository) UpdateUser(ctx context.Context, userID uuid.UUID, args *repository.UpdateUserArgs) error {
 	changes := map[string]interface{}{}
 	if args.Description.Valid {
 		changes["description"] = args.Description.String
@@ -204,9 +206,9 @@ func (r *UserRepository) UpdateUser(userID uuid.UUID, args *repository.UpdateUse
 		return nil
 	}
 
-	err := r.h.Transaction(func(tx database.SQLHandler) error {
+	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		user := new(model.User)
-		err := tx.
+		err :=tx.WithContext(ctx).
 			Where(&model.User{ID: userID}).
 			First(user).
 			Error()
@@ -214,7 +216,7 @@ func (r *UserRepository) UpdateUser(userID uuid.UUID, args *repository.UpdateUse
 			return convertError(err)
 		}
 
-		err = tx.Model(user).Updates(changes).Error()
+		err =tx.WithContext(ctx).Model(user).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -227,8 +229,8 @@ func (r *UserRepository) UpdateUser(userID uuid.UUID, args *repository.UpdateUse
 	return nil
 }
 
-func (r *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
-	err := r.h.
+func (r *UserRepository) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error) {
+	err := r.h.WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -237,7 +239,7 @@ func (r *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error
 	}
 
 	accounts := make([]*model.Account, 0)
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Where(&model.Account{UserID: userID}).
 		Find(&accounts).
 		Error()
@@ -258,9 +260,9 @@ func (r *UserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error
 	return result, nil
 }
 
-func (r *UserRepository) GetAccount(userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
+func (r *UserRepository) GetAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
 	account := &model.Account{}
-	err := r.h.
+	err := r.h.WithContext(ctx).
 		Where(&model.Account{ID: accountID, UserID: userID}).
 		First(account).
 		Error()
@@ -279,7 +281,7 @@ func (r *UserRepository) GetAccount(userID uuid.UUID, accountID uuid.UUID) (*dom
 	return result, nil
 }
 
-func (r *UserRepository) CreateAccount(userID uuid.UUID, args *repository.CreateAccountArgs) (*domain.Account, error) {
+func (r *UserRepository) CreateAccount(ctx context.Context, userID uuid.UUID, args *repository.CreateAccountArgs) (*domain.Account, error) {
 	if !domain.IsValidAccountURL(args.Type, args.URL) {
 		return nil, repository.ErrInvalidArg
 	}
@@ -292,13 +294,13 @@ func (r *UserRepository) CreateAccount(userID uuid.UUID, args *repository.Create
 		UserID: userID,
 		Check:  args.PrPermitted,
 	}
-	err := r.h.Create(&account).Error()
+	err := r.h.WithContext(ctx).Create(&account).Error()
 	if err != nil {
 		return nil, convertError(err)
 	}
 
 	ver := new(model.Account)
-	if err := r.h.
+	if err := r.h.WithContext(ctx).
 		Where(&model.Account{ID: account.ID}).
 		First(ver).
 		Error(); err != nil {
@@ -314,7 +316,7 @@ func (r *UserRepository) CreateAccount(userID uuid.UUID, args *repository.Create
 	}, nil
 }
 
-func (r *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error {
+func (r *UserRepository) UpdateAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error {
 	changes := map[string]interface{}{}
 	if args.DisplayName.Valid {
 		changes["name"] = args.DisplayName.String
@@ -333,9 +335,9 @@ func (r *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID, ar
 		return nil
 	}
 
-	err := r.h.Transaction(func(tx database.SQLHandler) error {
+	err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
 		account := new(model.Account)
-		err := tx.
+		err :=tx.WithContext(ctx).
 			Where(&model.Account{ID: accountID, UserID: userID}).
 			First(account).
 			Error()
@@ -358,7 +360,7 @@ func (r *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID, ar
 			}
 		}
 
-		err = tx.Model(account).Updates(changes).Error()
+		err =tx.WithContext(ctx).Model(account).Updates(changes).Error()
 		if err != nil {
 			return convertError(err)
 		}
@@ -367,16 +369,16 @@ func (r *UserRepository) UpdateAccount(userID uuid.UUID, accountID uuid.UUID, ar
 	return convertError(err)
 }
 
-func (r *UserRepository) DeleteAccount(userID uuid.UUID, accountID uuid.UUID) error {
-	if err := r.h.Transaction(func(tx database.SQLHandler) error {
-		if err := tx.
+func (r *UserRepository) DeleteAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) error {
+	if err := r.h.WithContext(ctx).Transaction(func(tx database.SQLHandler) error {
+		if err :=tx.WithContext(ctx).
 			Where(&model.Account{ID: accountID, UserID: userID}).
 			First(&model.Account{}).
 			Error(); err != nil {
 			return convertError(err)
 		}
 
-		if err := tx.
+		if err :=tx.WithContext(ctx).
 			Where(&model.Account{ID: accountID, UserID: userID}).
 			Delete(&model.Account{}).
 			Error(); err != nil {
@@ -391,8 +393,8 @@ func (r *UserRepository) DeleteAccount(userID uuid.UUID, accountID uuid.UUID) er
 	return nil
 }
 
-func (r *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, error) {
-	err := r.h.
+func (r *UserRepository) GetProjects(ctx context.Context, userID uuid.UUID) ([]*domain.UserProject, error) {
+	err := r.h.WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -401,7 +403,7 @@ func (r *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, e
 	}
 
 	projects := make([]*model.ProjectMember, 0)
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Preload("Project").
 		Where(&model.ProjectMember{UserID: userID}).
 		Find(&projects).
@@ -423,8 +425,8 @@ func (r *UserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, e
 	return res, nil
 }
 
-func (r *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.UserGroup, error) {
-	err := r.h.
+func (r *UserRepository) GetGroupsByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.UserGroup, error) {
+	err := r.h.WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -433,7 +435,7 @@ func (r *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.UserGrou
 	}
 
 	groups := make([]*model.GroupUserBelonging, 0)
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Preload("Group").
 		Where(&model.GroupUserBelonging{UserID: userID}).
 		Find(&groups).
@@ -463,8 +465,8 @@ func (r *UserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.UserGrou
 	return result, nil
 }
 
-func (r *UserRepository) GetContests(userID uuid.UUID) ([]*domain.UserContest, error) {
-	err := r.h.
+func (r *UserRepository) GetContests(ctx context.Context, userID uuid.UUID) ([]*domain.UserContest, error) {
+	err := r.h.WithContext(ctx).
 		Where(&model.User{ID: userID}).
 		First(&model.User{}).
 		Error()
@@ -473,7 +475,7 @@ func (r *UserRepository) GetContests(userID uuid.UUID) ([]*domain.UserContest, e
 	}
 
 	contestTeamUserBelongings := make([]*model.ContestTeamUserBelonging, 0)
-	err = r.h.
+	err = r.h.WithContext(ctx).
 		Preload("ContestTeam.Contest").
 		Where(&model.ContestTeamUserBelonging{UserID: userID}).
 		Find(&contestTeamUserBelongings).

--- a/interfaces/repository/user_impl_test.go
+++ b/interfaces/repository/user_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -320,7 +321,7 @@ func TestUserRepository_GetUsers(t *testing.T) {
 			tt.setup(t, f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetUsers(tt.args.args)
+			got, err := repo.GetUsers(context.Background(), tt.args.args)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -464,7 +465,7 @@ func TestUserRepository_GetUser(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetUser(tt.args.id)
+			got, err := repo.GetUser(context.Background(), tt.args.id)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -569,7 +570,7 @@ func TestUserRepository_CreateUser(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.CreateUser(tt.args.args)
+			got, err := repo.CreateUser(context.Background(), tt.args.args)
 			if tt.want != nil && got != nil {
 				tt.want.ID = got.ID // 関数内でIDを生成するためここで合わせる
 			}
@@ -656,7 +657,7 @@ func TestUserRepository_GetAccounts(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetAccounts(tt.args.userID)
+			got, err := repo.GetAccounts(context.Background(), tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -726,7 +727,7 @@ func TestUserRepository_GetAccount(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetAccount(tt.args.userID, tt.args.accountID)
+			got, err := repo.GetAccount(context.Background(), tt.args.userID, tt.args.accountID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -827,7 +828,7 @@ func TestUserRepository_UpdateUser(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			tt.assertion(t, repo.UpdateUser(tt.args.id, tt.args.args))
+			tt.assertion(t, repo.UpdateUser(context.Background(), tt.args.id, tt.args.args))
 		})
 	}
 }
@@ -937,7 +938,7 @@ func TestUserRepository_CreateAccount(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.CreateAccount(tt.args.id, tt.args.args)
+			got, err := repo.CreateAccount(context.Background(), tt.args.id, tt.args.args)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -1042,7 +1043,7 @@ func TestUserRepository_UpdateAccount(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			tt.assertion(t, repo.UpdateAccount(tt.args.userID, tt.args.accountID, tt.args.args))
+			tt.assertion(t, repo.UpdateAccount(context.Background(), tt.args.userID, tt.args.accountID, tt.args.args))
 		})
 	}
 }
@@ -1125,7 +1126,7 @@ func TestUserRepository_DeleteAccount(t *testing.T) {
 			tt.setup(f, tt.args)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			tt.assertion(t, repo.DeleteAccount(tt.args.userID, tt.args.accountID))
+			tt.assertion(t, repo.DeleteAccount(context.Background(), tt.args.userID, tt.args.accountID))
 		})
 	}
 }
@@ -1218,7 +1219,7 @@ func TestUserRepository_GetProjects(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetProjects(tt.args.userID)
+			got, err := repo.GetProjects(context.Background(), tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -1311,7 +1312,7 @@ func TestUserRepository_GetGroupsByUserID(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetGroupsByUserID(tt.args.userID)
+			got, err := repo.GetGroupsByUserID(context.Background(), tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -1483,7 +1484,7 @@ func TestUserRepository_GetContests(t *testing.T) {
 			tt.setup(f, tt.args, tt.want)
 			repo := NewUserRepository(f.h, f.portal, f.traq)
 			// Assertion
-			got, err := repo.GetContests(tt.args.userID)
+			got, err := repo.GetContests(context.Background(), tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/usecases/repository/contest_repository.go
+++ b/usecases/repository/contest_repository.go
@@ -3,6 +3,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/traPtitech/traPortfolio/domain"
@@ -43,17 +44,17 @@ type UpdateContestTeamArgs struct {
 }
 
 type ContestRepository interface {
-	GetContests() ([]*domain.Contest, error)
-	GetContest(contestID uuid.UUID) (*domain.ContestDetail, error)
-	CreateContest(args *CreateContestArgs) (*domain.ContestDetail, error)
-	UpdateContest(contestID uuid.UUID, args *UpdateContestArgs) error
-	DeleteContest(contestID uuid.UUID) error
-	GetContestTeams(contestID uuid.UUID) ([]*domain.ContestTeam, error)
-	GetContestTeam(contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error)
-	CreateContestTeam(contestID uuid.UUID, args *CreateContestTeamArgs) (*domain.ContestTeamDetail, error)
-	UpdateContestTeam(teamID uuid.UUID, args *UpdateContestTeamArgs) error
-	DeleteContestTeam(contestID uuid.UUID, teamID uuid.UUID) error
-	GetContestTeamMembers(contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error)
-	AddContestTeamMembers(teamID uuid.UUID, memberIDs []uuid.UUID) error
-	EditContestTeamMembers(teamID uuid.UUID, memberIDs []uuid.UUID) error
+	GetContests(ctx context.Context) ([]*domain.Contest, error)
+	GetContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error)
+	CreateContest(ctx context.Context, args *CreateContestArgs) (*domain.ContestDetail, error)
+	UpdateContest(ctx context.Context, contestID uuid.UUID, args *UpdateContestArgs) error
+	DeleteContest(ctx context.Context, contestID uuid.UUID) error
+	GetContestTeams(ctx context.Context, contestID uuid.UUID) ([]*domain.ContestTeam, error)
+	GetContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error)
+	CreateContestTeam(ctx context.Context, contestID uuid.UUID, args *CreateContestTeamArgs) (*domain.ContestTeamDetail, error)
+	UpdateContestTeam(ctx context.Context, teamID uuid.UUID, args *UpdateContestTeamArgs) error
+	DeleteContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) error
+	GetContestTeamMembers(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error)
+	AddContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error
+	EditContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error
 }

--- a/usecases/repository/event_repository.go
+++ b/usecases/repository/event_repository.go
@@ -3,6 +3,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/util/optional"
@@ -18,9 +20,9 @@ type UpdateEventLevelArgs struct {
 }
 
 type EventRepository interface {
-	GetEvents() ([]*domain.Event, error)
-	GetEvent(eventID uuid.UUID) (*domain.EventDetail, error)
-	CreateEventLevel(args *CreateEventLevelArgs) error
-	UpdateEventLevel(eventID uuid.UUID, args *UpdateEventLevelArgs) error
-	GetUserEvents(userID uuid.UUID) ([]*domain.Event, error)
+	GetEvents(ctx context.Context) ([]*domain.Event, error)
+	GetEvent(ctx context.Context, eventID uuid.UUID) (*domain.EventDetail, error)
+	CreateEventLevel(ctx context.Context, args *CreateEventLevelArgs) error
+	UpdateEventLevel(ctx context.Context, eventID uuid.UUID, args *UpdateEventLevelArgs) error
+	GetUserEvents(ctx context.Context, userID uuid.UUID) ([]*domain.Event, error)
 }

--- a/usecases/repository/group_repository.go
+++ b/usecases/repository/group_repository.go
@@ -3,11 +3,13 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 )
 
 type GroupRepository interface {
-	GetAllGroups() ([]*domain.Group, error)
-	GetGroup(groupID uuid.UUID) (*domain.GroupDetail, error)
+	GetAllGroups(ctx context.Context) ([]*domain.Group, error)
+	GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.GroupDetail, error)
 }

--- a/usecases/repository/mock_repository/mock_contest_repository.go
+++ b/usecases/repository/mock_repository/mock_contest_repository.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,190 +38,190 @@ func (m *MockContestRepository) EXPECT() *MockContestRepositoryMockRecorder {
 }
 
 // AddContestTeamMembers mocks base method.
-func (m *MockContestRepository) AddContestTeamMembers(teamID uuid.UUID, memberIDs []uuid.UUID) error {
+func (m *MockContestRepository) AddContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddContestTeamMembers", teamID, memberIDs)
+	ret := m.ctrl.Call(m, "AddContestTeamMembers", ctx, teamID, memberIDs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddContestTeamMembers indicates an expected call of AddContestTeamMembers.
-func (mr *MockContestRepositoryMockRecorder) AddContestTeamMembers(teamID, memberIDs interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) AddContestTeamMembers(ctx, teamID, memberIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).AddContestTeamMembers), teamID, memberIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).AddContestTeamMembers), ctx, teamID, memberIDs)
 }
 
 // CreateContest mocks base method.
-func (m *MockContestRepository) CreateContest(args *repository.CreateContestArgs) (*domain.ContestDetail, error) {
+func (m *MockContestRepository) CreateContest(ctx context.Context, args *repository.CreateContestArgs) (*domain.ContestDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContest", args)
+	ret := m.ctrl.Call(m, "CreateContest", ctx, args)
 	ret0, _ := ret[0].(*domain.ContestDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateContest indicates an expected call of CreateContest.
-func (mr *MockContestRepositoryMockRecorder) CreateContest(args interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) CreateContest(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContest", reflect.TypeOf((*MockContestRepository)(nil).CreateContest), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContest", reflect.TypeOf((*MockContestRepository)(nil).CreateContest), ctx, args)
 }
 
 // CreateContestTeam mocks base method.
-func (m *MockContestRepository) CreateContestTeam(contestID uuid.UUID, args *repository.CreateContestTeamArgs) (*domain.ContestTeamDetail, error) {
+func (m *MockContestRepository) CreateContestTeam(ctx context.Context, contestID uuid.UUID, args *repository.CreateContestTeamArgs) (*domain.ContestTeamDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContestTeam", contestID, args)
+	ret := m.ctrl.Call(m, "CreateContestTeam", ctx, contestID, args)
 	ret0, _ := ret[0].(*domain.ContestTeamDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateContestTeam indicates an expected call of CreateContestTeam.
-func (mr *MockContestRepositoryMockRecorder) CreateContestTeam(contestID, args interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) CreateContestTeam(ctx, contestID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContestTeam", reflect.TypeOf((*MockContestRepository)(nil).CreateContestTeam), contestID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContestTeam", reflect.TypeOf((*MockContestRepository)(nil).CreateContestTeam), ctx, contestID, args)
 }
 
 // DeleteContest mocks base method.
-func (m *MockContestRepository) DeleteContest(contestID uuid.UUID) error {
+func (m *MockContestRepository) DeleteContest(ctx context.Context, contestID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContest", contestID)
+	ret := m.ctrl.Call(m, "DeleteContest", ctx, contestID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContest indicates an expected call of DeleteContest.
-func (mr *MockContestRepositoryMockRecorder) DeleteContest(contestID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) DeleteContest(ctx, contestID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContest", reflect.TypeOf((*MockContestRepository)(nil).DeleteContest), contestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContest", reflect.TypeOf((*MockContestRepository)(nil).DeleteContest), ctx, contestID)
 }
 
 // DeleteContestTeam mocks base method.
-func (m *MockContestRepository) DeleteContestTeam(contestID, teamID uuid.UUID) error {
+func (m *MockContestRepository) DeleteContestTeam(ctx context.Context, contestID, teamID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContestTeam", contestID, teamID)
+	ret := m.ctrl.Call(m, "DeleteContestTeam", ctx, contestID, teamID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContestTeam indicates an expected call of DeleteContestTeam.
-func (mr *MockContestRepositoryMockRecorder) DeleteContestTeam(contestID, teamID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) DeleteContestTeam(ctx, contestID, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContestTeam", reflect.TypeOf((*MockContestRepository)(nil).DeleteContestTeam), contestID, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContestTeam", reflect.TypeOf((*MockContestRepository)(nil).DeleteContestTeam), ctx, contestID, teamID)
 }
 
 // EditContestTeamMembers mocks base method.
-func (m *MockContestRepository) EditContestTeamMembers(teamID uuid.UUID, memberIDs []uuid.UUID) error {
+func (m *MockContestRepository) EditContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EditContestTeamMembers", teamID, memberIDs)
+	ret := m.ctrl.Call(m, "EditContestTeamMembers", ctx, teamID, memberIDs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EditContestTeamMembers indicates an expected call of EditContestTeamMembers.
-func (mr *MockContestRepositoryMockRecorder) EditContestTeamMembers(teamID, memberIDs interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) EditContestTeamMembers(ctx, teamID, memberIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).EditContestTeamMembers), teamID, memberIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).EditContestTeamMembers), ctx, teamID, memberIDs)
 }
 
 // GetContest mocks base method.
-func (m *MockContestRepository) GetContest(contestID uuid.UUID) (*domain.ContestDetail, error) {
+func (m *MockContestRepository) GetContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContest", contestID)
+	ret := m.ctrl.Call(m, "GetContest", ctx, contestID)
 	ret0, _ := ret[0].(*domain.ContestDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContest indicates an expected call of GetContest.
-func (mr *MockContestRepositoryMockRecorder) GetContest(contestID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) GetContest(ctx, contestID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContest", reflect.TypeOf((*MockContestRepository)(nil).GetContest), contestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContest", reflect.TypeOf((*MockContestRepository)(nil).GetContest), ctx, contestID)
 }
 
 // GetContestTeam mocks base method.
-func (m *MockContestRepository) GetContestTeam(contestID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
+func (m *MockContestRepository) GetContestTeam(ctx context.Context, contestID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContestTeam", contestID, teamID)
+	ret := m.ctrl.Call(m, "GetContestTeam", ctx, contestID, teamID)
 	ret0, _ := ret[0].(*domain.ContestTeamDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContestTeam indicates an expected call of GetContestTeam.
-func (mr *MockContestRepositoryMockRecorder) GetContestTeam(contestID, teamID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) GetContestTeam(ctx, contestID, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeam", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeam), contestID, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeam", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeam), ctx, contestID, teamID)
 }
 
 // GetContestTeamMembers mocks base method.
-func (m *MockContestRepository) GetContestTeamMembers(contestID, teamID uuid.UUID) ([]*domain.User, error) {
+func (m *MockContestRepository) GetContestTeamMembers(ctx context.Context, contestID, teamID uuid.UUID) ([]*domain.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContestTeamMembers", contestID, teamID)
+	ret := m.ctrl.Call(m, "GetContestTeamMembers", ctx, contestID, teamID)
 	ret0, _ := ret[0].([]*domain.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContestTeamMembers indicates an expected call of GetContestTeamMembers.
-func (mr *MockContestRepositoryMockRecorder) GetContestTeamMembers(contestID, teamID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) GetContestTeamMembers(ctx, contestID, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeamMembers), contestID, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeamMembers", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeamMembers), ctx, contestID, teamID)
 }
 
 // GetContestTeams mocks base method.
-func (m *MockContestRepository) GetContestTeams(contestID uuid.UUID) ([]*domain.ContestTeam, error) {
+func (m *MockContestRepository) GetContestTeams(ctx context.Context, contestID uuid.UUID) ([]*domain.ContestTeam, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContestTeams", contestID)
+	ret := m.ctrl.Call(m, "GetContestTeams", ctx, contestID)
 	ret0, _ := ret[0].([]*domain.ContestTeam)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContestTeams indicates an expected call of GetContestTeams.
-func (mr *MockContestRepositoryMockRecorder) GetContestTeams(contestID interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) GetContestTeams(ctx, contestID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeams", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeams), contestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContestTeams", reflect.TypeOf((*MockContestRepository)(nil).GetContestTeams), ctx, contestID)
 }
 
 // GetContests mocks base method.
-func (m *MockContestRepository) GetContests() ([]*domain.Contest, error) {
+func (m *MockContestRepository) GetContests(ctx context.Context) ([]*domain.Contest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContests")
+	ret := m.ctrl.Call(m, "GetContests", ctx)
 	ret0, _ := ret[0].([]*domain.Contest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContests indicates an expected call of GetContests.
-func (mr *MockContestRepositoryMockRecorder) GetContests() *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) GetContests(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContests", reflect.TypeOf((*MockContestRepository)(nil).GetContests))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContests", reflect.TypeOf((*MockContestRepository)(nil).GetContests), ctx)
 }
 
 // UpdateContest mocks base method.
-func (m *MockContestRepository) UpdateContest(contestID uuid.UUID, args *repository.UpdateContestArgs) error {
+func (m *MockContestRepository) UpdateContest(ctx context.Context, contestID uuid.UUID, args *repository.UpdateContestArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateContest", contestID, args)
+	ret := m.ctrl.Call(m, "UpdateContest", ctx, contestID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateContest indicates an expected call of UpdateContest.
-func (mr *MockContestRepositoryMockRecorder) UpdateContest(contestID, args interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) UpdateContest(ctx, contestID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContest", reflect.TypeOf((*MockContestRepository)(nil).UpdateContest), contestID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContest", reflect.TypeOf((*MockContestRepository)(nil).UpdateContest), ctx, contestID, args)
 }
 
 // UpdateContestTeam mocks base method.
-func (m *MockContestRepository) UpdateContestTeam(teamID uuid.UUID, args *repository.UpdateContestTeamArgs) error {
+func (m *MockContestRepository) UpdateContestTeam(ctx context.Context, teamID uuid.UUID, args *repository.UpdateContestTeamArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateContestTeam", teamID, args)
+	ret := m.ctrl.Call(m, "UpdateContestTeam", ctx, teamID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateContestTeam indicates an expected call of UpdateContestTeam.
-func (mr *MockContestRepositoryMockRecorder) UpdateContestTeam(teamID, args interface{}) *gomock.Call {
+func (mr *MockContestRepositoryMockRecorder) UpdateContestTeam(ctx, teamID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContestTeam", reflect.TypeOf((*MockContestRepository)(nil).UpdateContestTeam), teamID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContestTeam", reflect.TypeOf((*MockContestRepository)(nil).UpdateContestTeam), ctx, teamID, args)
 }

--- a/usecases/repository/mock_repository/mock_event_repository.go
+++ b/usecases/repository/mock_repository/mock_event_repository.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,74 +38,74 @@ func (m *MockEventRepository) EXPECT() *MockEventRepositoryMockRecorder {
 }
 
 // CreateEventLevel mocks base method.
-func (m *MockEventRepository) CreateEventLevel(args *repository.CreateEventLevelArgs) error {
+func (m *MockEventRepository) CreateEventLevel(ctx context.Context, args *repository.CreateEventLevelArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateEventLevel", args)
+	ret := m.ctrl.Call(m, "CreateEventLevel", ctx, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateEventLevel indicates an expected call of CreateEventLevel.
-func (mr *MockEventRepositoryMockRecorder) CreateEventLevel(args interface{}) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) CreateEventLevel(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEventLevel", reflect.TypeOf((*MockEventRepository)(nil).CreateEventLevel), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEventLevel", reflect.TypeOf((*MockEventRepository)(nil).CreateEventLevel), ctx, args)
 }
 
 // GetEvent mocks base method.
-func (m *MockEventRepository) GetEvent(eventID uuid.UUID) (*domain.EventDetail, error) {
+func (m *MockEventRepository) GetEvent(ctx context.Context, eventID uuid.UUID) (*domain.EventDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEvent", eventID)
+	ret := m.ctrl.Call(m, "GetEvent", ctx, eventID)
 	ret0, _ := ret[0].(*domain.EventDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEvent indicates an expected call of GetEvent.
-func (mr *MockEventRepositoryMockRecorder) GetEvent(eventID interface{}) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) GetEvent(ctx, eventID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockEventRepository)(nil).GetEvent), eventID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockEventRepository)(nil).GetEvent), ctx, eventID)
 }
 
 // GetEvents mocks base method.
-func (m *MockEventRepository) GetEvents() ([]*domain.Event, error) {
+func (m *MockEventRepository) GetEvents(ctx context.Context) ([]*domain.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEvents")
+	ret := m.ctrl.Call(m, "GetEvents", ctx)
 	ret0, _ := ret[0].([]*domain.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEvents indicates an expected call of GetEvents.
-func (mr *MockEventRepositoryMockRecorder) GetEvents() *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) GetEvents(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvents", reflect.TypeOf((*MockEventRepository)(nil).GetEvents))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvents", reflect.TypeOf((*MockEventRepository)(nil).GetEvents), ctx)
 }
 
 // GetUserEvents mocks base method.
-func (m *MockEventRepository) GetUserEvents(userID uuid.UUID) ([]*domain.Event, error) {
+func (m *MockEventRepository) GetUserEvents(ctx context.Context, userID uuid.UUID) ([]*domain.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserEvents", userID)
+	ret := m.ctrl.Call(m, "GetUserEvents", ctx, userID)
 	ret0, _ := ret[0].([]*domain.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserEvents indicates an expected call of GetUserEvents.
-func (mr *MockEventRepositoryMockRecorder) GetUserEvents(userID interface{}) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) GetUserEvents(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserEvents", reflect.TypeOf((*MockEventRepository)(nil).GetUserEvents), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserEvents", reflect.TypeOf((*MockEventRepository)(nil).GetUserEvents), ctx, userID)
 }
 
 // UpdateEventLevel mocks base method.
-func (m *MockEventRepository) UpdateEventLevel(eventID uuid.UUID, args *repository.UpdateEventLevelArgs) error {
+func (m *MockEventRepository) UpdateEventLevel(ctx context.Context, eventID uuid.UUID, args *repository.UpdateEventLevelArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEventLevel", eventID, args)
+	ret := m.ctrl.Call(m, "UpdateEventLevel", ctx, eventID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateEventLevel indicates an expected call of UpdateEventLevel.
-func (mr *MockEventRepositoryMockRecorder) UpdateEventLevel(eventID, args interface{}) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) UpdateEventLevel(ctx, eventID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEventLevel", reflect.TypeOf((*MockEventRepository)(nil).UpdateEventLevel), eventID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEventLevel", reflect.TypeOf((*MockEventRepository)(nil).UpdateEventLevel), ctx, eventID, args)
 }

--- a/usecases/repository/mock_repository/mock_group_repository.go
+++ b/usecases/repository/mock_repository/mock_group_repository.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -36,31 +37,31 @@ func (m *MockGroupRepository) EXPECT() *MockGroupRepositoryMockRecorder {
 }
 
 // GetAllGroups mocks base method.
-func (m *MockGroupRepository) GetAllGroups() ([]*domain.Group, error) {
+func (m *MockGroupRepository) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllGroups")
+	ret := m.ctrl.Call(m, "GetAllGroups", ctx)
 	ret0, _ := ret[0].([]*domain.Group)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllGroups indicates an expected call of GetAllGroups.
-func (mr *MockGroupRepositoryMockRecorder) GetAllGroups() *gomock.Call {
+func (mr *MockGroupRepositoryMockRecorder) GetAllGroups(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllGroups", reflect.TypeOf((*MockGroupRepository)(nil).GetAllGroups))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllGroups", reflect.TypeOf((*MockGroupRepository)(nil).GetAllGroups), ctx)
 }
 
 // GetGroup mocks base method.
-func (m *MockGroupRepository) GetGroup(groupID uuid.UUID) (*domain.GroupDetail, error) {
+func (m *MockGroupRepository) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.GroupDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroup", groupID)
+	ret := m.ctrl.Call(m, "GetGroup", ctx, groupID)
 	ret0, _ := ret[0].(*domain.GroupDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetGroup indicates an expected call of GetGroup.
-func (mr *MockGroupRepositoryMockRecorder) GetGroup(groupID interface{}) *gomock.Call {
+func (mr *MockGroupRepositoryMockRecorder) GetGroup(ctx, groupID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockGroupRepository)(nil).GetGroup), groupID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockGroupRepository)(nil).GetGroup), ctx, groupID)
 }

--- a/usecases/repository/mock_repository/mock_project_repository.go
+++ b/usecases/repository/mock_repository/mock_project_repository.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,103 +38,103 @@ func (m *MockProjectRepository) EXPECT() *MockProjectRepositoryMockRecorder {
 }
 
 // AddProjectMembers mocks base method.
-func (m *MockProjectRepository) AddProjectMembers(projectID uuid.UUID, args []*repository.CreateProjectMemberArgs) error {
+func (m *MockProjectRepository) AddProjectMembers(ctx context.Context, projectID uuid.UUID, args []*repository.CreateProjectMemberArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddProjectMembers", projectID, args)
+	ret := m.ctrl.Call(m, "AddProjectMembers", ctx, projectID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddProjectMembers indicates an expected call of AddProjectMembers.
-func (mr *MockProjectRepositoryMockRecorder) AddProjectMembers(projectID, args interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) AddProjectMembers(ctx, projectID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).AddProjectMembers), projectID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).AddProjectMembers), ctx, projectID, args)
 }
 
 // CreateProject mocks base method.
-func (m *MockProjectRepository) CreateProject(args *repository.CreateProjectArgs) (*domain.ProjectDetail, error) {
+func (m *MockProjectRepository) CreateProject(ctx context.Context, args *repository.CreateProjectArgs) (*domain.ProjectDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProject", args)
+	ret := m.ctrl.Call(m, "CreateProject", ctx, args)
 	ret0, _ := ret[0].(*domain.ProjectDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateProject indicates an expected call of CreateProject.
-func (mr *MockProjectRepositoryMockRecorder) CreateProject(args interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) CreateProject(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockProjectRepository)(nil).CreateProject), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockProjectRepository)(nil).CreateProject), ctx, args)
 }
 
 // DeleteProjectMembers mocks base method.
-func (m *MockProjectRepository) DeleteProjectMembers(projectID uuid.UUID, memberIDs []uuid.UUID) error {
+func (m *MockProjectRepository) DeleteProjectMembers(ctx context.Context, projectID uuid.UUID, memberIDs []uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteProjectMembers", projectID, memberIDs)
+	ret := m.ctrl.Call(m, "DeleteProjectMembers", ctx, projectID, memberIDs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteProjectMembers indicates an expected call of DeleteProjectMembers.
-func (mr *MockProjectRepositoryMockRecorder) DeleteProjectMembers(projectID, memberIDs interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) DeleteProjectMembers(ctx, projectID, memberIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).DeleteProjectMembers), projectID, memberIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).DeleteProjectMembers), ctx, projectID, memberIDs)
 }
 
 // GetProject mocks base method.
-func (m *MockProjectRepository) GetProject(projectID uuid.UUID) (*domain.ProjectDetail, error) {
+func (m *MockProjectRepository) GetProject(ctx context.Context, projectID uuid.UUID) (*domain.ProjectDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProject", projectID)
+	ret := m.ctrl.Call(m, "GetProject", ctx, projectID)
 	ret0, _ := ret[0].(*domain.ProjectDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProject indicates an expected call of GetProject.
-func (mr *MockProjectRepositoryMockRecorder) GetProject(projectID interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) GetProject(ctx, projectID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockProjectRepository)(nil).GetProject), projectID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockProjectRepository)(nil).GetProject), ctx, projectID)
 }
 
 // GetProjectMembers mocks base method.
-func (m *MockProjectRepository) GetProjectMembers(projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
+func (m *MockProjectRepository) GetProjectMembers(ctx context.Context, projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectMembers", projectID)
+	ret := m.ctrl.Call(m, "GetProjectMembers", ctx, projectID)
 	ret0, _ := ret[0].([]*domain.UserWithDuration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectMembers indicates an expected call of GetProjectMembers.
-func (mr *MockProjectRepositoryMockRecorder) GetProjectMembers(projectID interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) GetProjectMembers(ctx, projectID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).GetProjectMembers), projectID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectMembers", reflect.TypeOf((*MockProjectRepository)(nil).GetProjectMembers), ctx, projectID)
 }
 
 // GetProjects mocks base method.
-func (m *MockProjectRepository) GetProjects() ([]*domain.Project, error) {
+func (m *MockProjectRepository) GetProjects(ctx context.Context) ([]*domain.Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjects")
+	ret := m.ctrl.Call(m, "GetProjects", ctx)
 	ret0, _ := ret[0].([]*domain.Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjects indicates an expected call of GetProjects.
-func (mr *MockProjectRepositoryMockRecorder) GetProjects() *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) GetProjects(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockProjectRepository)(nil).GetProjects))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockProjectRepository)(nil).GetProjects), ctx)
 }
 
 // UpdateProject mocks base method.
-func (m *MockProjectRepository) UpdateProject(projectID uuid.UUID, args *repository.UpdateProjectArgs) error {
+func (m *MockProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UUID, args *repository.UpdateProjectArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateProject", projectID, args)
+	ret := m.ctrl.Call(m, "UpdateProject", ctx, projectID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateProject indicates an expected call of UpdateProject.
-func (mr *MockProjectRepositoryMockRecorder) UpdateProject(projectID, args interface{}) *gomock.Call {
+func (mr *MockProjectRepositoryMockRecorder) UpdateProject(ctx, projectID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProject", reflect.TypeOf((*MockProjectRepository)(nil).UpdateProject), projectID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProject", reflect.TypeOf((*MockProjectRepository)(nil).UpdateProject), ctx, projectID, args)
 }

--- a/usecases/repository/mock_repository/mock_user_repository.go
+++ b/usecases/repository/mock_repository/mock_user_repository.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -37,178 +38,178 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 }
 
 // CreateAccount mocks base method.
-func (m *MockUserRepository) CreateAccount(userID uuid.UUID, args *repository.CreateAccountArgs) (*domain.Account, error) {
+func (m *MockUserRepository) CreateAccount(ctx context.Context, userID uuid.UUID, args *repository.CreateAccountArgs) (*domain.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", userID, args)
+	ret := m.ctrl.Call(m, "CreateAccount", ctx, userID, args)
 	ret0, _ := ret[0].(*domain.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockUserRepositoryMockRecorder) CreateAccount(userID, args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) CreateAccount(ctx, userID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockUserRepository)(nil).CreateAccount), userID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockUserRepository)(nil).CreateAccount), ctx, userID, args)
 }
 
 // CreateUser mocks base method.
-func (m *MockUserRepository) CreateUser(args *repository.CreateUserArgs) (*domain.UserDetail, error) {
+func (m *MockUserRepository) CreateUser(ctx context.Context, args *repository.CreateUserArgs) (*domain.UserDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUser", args)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, args)
 	ret0, _ := ret[0].(*domain.UserDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockUserRepositoryMockRecorder) CreateUser(args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) CreateUser(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUserRepository)(nil).CreateUser), ctx, args)
 }
 
 // DeleteAccount mocks base method.
-func (m *MockUserRepository) DeleteAccount(userID, accountID uuid.UUID) error {
+func (m *MockUserRepository) DeleteAccount(ctx context.Context, userID, accountID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAccount", userID, accountID)
+	ret := m.ctrl.Call(m, "DeleteAccount", ctx, userID, accountID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAccount indicates an expected call of DeleteAccount.
-func (mr *MockUserRepositoryMockRecorder) DeleteAccount(userID, accountID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) DeleteAccount(ctx, userID, accountID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccount", reflect.TypeOf((*MockUserRepository)(nil).DeleteAccount), userID, accountID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccount", reflect.TypeOf((*MockUserRepository)(nil).DeleteAccount), ctx, userID, accountID)
 }
 
 // GetAccount mocks base method.
-func (m *MockUserRepository) GetAccount(userID, accountID uuid.UUID) (*domain.Account, error) {
+func (m *MockUserRepository) GetAccount(ctx context.Context, userID, accountID uuid.UUID) (*domain.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccount", userID, accountID)
+	ret := m.ctrl.Call(m, "GetAccount", ctx, userID, accountID)
 	ret0, _ := ret[0].(*domain.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAccount indicates an expected call of GetAccount.
-func (mr *MockUserRepositoryMockRecorder) GetAccount(userID, accountID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetAccount(ctx, userID, accountID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockUserRepository)(nil).GetAccount), userID, accountID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockUserRepository)(nil).GetAccount), ctx, userID, accountID)
 }
 
 // GetAccounts mocks base method.
-func (m *MockUserRepository) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
+func (m *MockUserRepository) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccounts", userID)
+	ret := m.ctrl.Call(m, "GetAccounts", ctx, userID)
 	ret0, _ := ret[0].([]*domain.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAccounts indicates an expected call of GetAccounts.
-func (mr *MockUserRepositoryMockRecorder) GetAccounts(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetAccounts(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetAccounts), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetAccounts), ctx, userID)
 }
 
 // GetContests mocks base method.
-func (m *MockUserRepository) GetContests(userID uuid.UUID) ([]*domain.UserContest, error) {
+func (m *MockUserRepository) GetContests(ctx context.Context, userID uuid.UUID) ([]*domain.UserContest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContests", userID)
+	ret := m.ctrl.Call(m, "GetContests", ctx, userID)
 	ret0, _ := ret[0].([]*domain.UserContest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContests indicates an expected call of GetContests.
-func (mr *MockUserRepositoryMockRecorder) GetContests(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetContests(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContests", reflect.TypeOf((*MockUserRepository)(nil).GetContests), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContests", reflect.TypeOf((*MockUserRepository)(nil).GetContests), ctx, userID)
 }
 
 // GetGroupsByUserID mocks base method.
-func (m *MockUserRepository) GetGroupsByUserID(userID uuid.UUID) ([]*domain.UserGroup, error) {
+func (m *MockUserRepository) GetGroupsByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.UserGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroupsByUserID", userID)
+	ret := m.ctrl.Call(m, "GetGroupsByUserID", ctx, userID)
 	ret0, _ := ret[0].([]*domain.UserGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetGroupsByUserID indicates an expected call of GetGroupsByUserID.
-func (mr *MockUserRepositoryMockRecorder) GetGroupsByUserID(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetGroupsByUserID(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsByUserID", reflect.TypeOf((*MockUserRepository)(nil).GetGroupsByUserID), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsByUserID", reflect.TypeOf((*MockUserRepository)(nil).GetGroupsByUserID), ctx, userID)
 }
 
 // GetProjects mocks base method.
-func (m *MockUserRepository) GetProjects(userID uuid.UUID) ([]*domain.UserProject, error) {
+func (m *MockUserRepository) GetProjects(ctx context.Context, userID uuid.UUID) ([]*domain.UserProject, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjects", userID)
+	ret := m.ctrl.Call(m, "GetProjects", ctx, userID)
 	ret0, _ := ret[0].([]*domain.UserProject)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjects indicates an expected call of GetProjects.
-func (mr *MockUserRepositoryMockRecorder) GetProjects(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetProjects(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockUserRepository)(nil).GetProjects), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockUserRepository)(nil).GetProjects), ctx, userID)
 }
 
 // GetUser mocks base method.
-func (m *MockUserRepository) GetUser(userID uuid.UUID) (*domain.UserDetail, error) {
+func (m *MockUserRepository) GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", userID)
+	ret := m.ctrl.Call(m, "GetUser", ctx, userID)
 	ret0, _ := ret[0].(*domain.UserDetail)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUser indicates an expected call of GetUser.
-func (mr *MockUserRepositoryMockRecorder) GetUser(userID interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUser(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockUserRepository)(nil).GetUser), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockUserRepository)(nil).GetUser), ctx, userID)
 }
 
 // GetUsers mocks base method.
-func (m *MockUserRepository) GetUsers(args *repository.GetUsersArgs) ([]*domain.User, error) {
+func (m *MockUserRepository) GetUsers(ctx context.Context, args *repository.GetUsersArgs) ([]*domain.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUsers", args)
+	ret := m.ctrl.Call(m, "GetUsers", ctx, args)
 	ret0, _ := ret[0].([]*domain.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUsers indicates an expected call of GetUsers.
-func (mr *MockUserRepositoryMockRecorder) GetUsers(args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) GetUsers(ctx, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockUserRepository)(nil).GetUsers), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockUserRepository)(nil).GetUsers), ctx, args)
 }
 
 // UpdateAccount mocks base method.
-func (m *MockUserRepository) UpdateAccount(userID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error {
+func (m *MockUserRepository) UpdateAccount(ctx context.Context, userID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAccount", userID, accountID, args)
+	ret := m.ctrl.Call(m, "UpdateAccount", ctx, userID, accountID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAccount indicates an expected call of UpdateAccount.
-func (mr *MockUserRepositoryMockRecorder) UpdateAccount(userID, accountID, args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UpdateAccount(ctx, userID, accountID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccount", reflect.TypeOf((*MockUserRepository)(nil).UpdateAccount), userID, accountID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccount", reflect.TypeOf((*MockUserRepository)(nil).UpdateAccount), ctx, userID, accountID, args)
 }
 
 // UpdateUser mocks base method.
-func (m *MockUserRepository) UpdateUser(userID uuid.UUID, args *repository.UpdateUserArgs) error {
+func (m *MockUserRepository) UpdateUser(ctx context.Context, userID uuid.UUID, args *repository.UpdateUserArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUser", userID, args)
+	ret := m.ctrl.Call(m, "UpdateUser", ctx, userID, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateUser indicates an expected call of UpdateUser.
-func (mr *MockUserRepositoryMockRecorder) UpdateUser(userID, args interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UpdateUser(ctx, userID, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), userID, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), ctx, userID, args)
 }

--- a/usecases/repository/project_repository.go
+++ b/usecases/repository/project_repository.go
@@ -3,6 +3,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/util/optional"
@@ -37,11 +39,11 @@ type CreateProjectMemberArgs struct {
 }
 
 type ProjectRepository interface {
-	GetProjects() ([]*domain.Project, error)
-	GetProject(projectID uuid.UUID) (*domain.ProjectDetail, error)
-	CreateProject(args *CreateProjectArgs) (*domain.ProjectDetail, error)
-	UpdateProject(projectID uuid.UUID, args *UpdateProjectArgs) error
-	GetProjectMembers(projectID uuid.UUID) ([]*domain.UserWithDuration, error)
-	AddProjectMembers(projectID uuid.UUID, args []*CreateProjectMemberArgs) error
-	DeleteProjectMembers(projectID uuid.UUID, memberIDs []uuid.UUID) error
+	GetProjects(ctx context.Context) ([]*domain.Project, error)
+	GetProject(ctx context.Context, projectID uuid.UUID) (*domain.ProjectDetail, error)
+	CreateProject(ctx context.Context, args *CreateProjectArgs) (*domain.ProjectDetail, error)
+	UpdateProject(ctx context.Context, projectID uuid.UUID, args *UpdateProjectArgs) error
+	GetProjectMembers(ctx context.Context, projectID uuid.UUID) ([]*domain.UserWithDuration, error)
+	AddProjectMembers(ctx context.Context, projectID uuid.UUID, args []*CreateProjectMemberArgs) error
+	DeleteProjectMembers(ctx context.Context, projectID uuid.UUID, memberIDs []uuid.UUID) error
 }

--- a/usecases/repository/user_repository.go
+++ b/usecases/repository/user_repository.go
@@ -3,6 +3,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/util/optional"
@@ -40,16 +42,16 @@ type UpdateAccountArgs struct {
 }
 
 type UserRepository interface {
-	GetUsers(args *GetUsersArgs) ([]*domain.User, error)
-	GetUser(userID uuid.UUID) (*domain.UserDetail, error)
-	CreateUser(args *CreateUserArgs) (*domain.UserDetail, error)
-	UpdateUser(userID uuid.UUID, args *UpdateUserArgs) error
-	GetAccounts(userID uuid.UUID) ([]*domain.Account, error)
-	GetAccount(userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error)
-	CreateAccount(userID uuid.UUID, args *CreateAccountArgs) (*domain.Account, error)
-	UpdateAccount(userID uuid.UUID, accountID uuid.UUID, args *UpdateAccountArgs) error
-	DeleteAccount(userID uuid.UUID, accountID uuid.UUID) error
-	GetProjects(userID uuid.UUID) ([]*domain.UserProject, error)
-	GetContests(userID uuid.UUID) ([]*domain.UserContest, error)
-	GetGroupsByUserID(userID uuid.UUID) ([]*domain.UserGroup, error)
+	GetUsers(ctx context.Context, args *GetUsersArgs) ([]*domain.User, error)
+	GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error)
+	CreateUser(ctx context.Context, args *CreateUserArgs) (*domain.UserDetail, error)
+	UpdateUser(ctx context.Context, userID uuid.UUID, args *UpdateUserArgs) error
+	GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error)
+	GetAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error)
+	CreateAccount(ctx context.Context, userID uuid.UUID, args *CreateAccountArgs) (*domain.Account, error)
+	UpdateAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID, args *UpdateAccountArgs) error
+	DeleteAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) error
+	GetProjects(ctx context.Context, userID uuid.UUID) ([]*domain.UserProject, error)
+	GetContests(ctx context.Context, userID uuid.UUID) ([]*domain.UserContest, error)
+	GetGroupsByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.UserGroup, error)
 }

--- a/usecases/service/contest.go
+++ b/usecases/service/contest.go
@@ -40,7 +40,7 @@ func NewContestService(repo repository.ContestRepository) ContestService {
 }
 
 func (s *contestService) GetContests(ctx context.Context) ([]*domain.Contest, error) {
-	contest, err := s.repo.GetContests()
+	contest, err := s.repo.GetContests(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,12 +49,12 @@ func (s *contestService) GetContests(ctx context.Context) ([]*domain.Contest, er
 }
 
 func (s *contestService) GetContest(ctx context.Context, contestID uuid.UUID) (*domain.ContestDetail, error) {
-	contest, err := s.repo.GetContest(contestID)
+	contest, err := s.repo.GetContest(ctx, contestID)
 	if err != nil {
 		return nil, err
 	}
 
-	teams, err := s.repo.GetContestTeams(contestID)
+	teams, err := s.repo.GetContestTeams(ctx, contestID)
 	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s *contestService) GetContest(ctx context.Context, contestID uuid.UUID) (*
 }
 
 func (s *contestService) CreateContest(ctx context.Context, args *repository.CreateContestArgs) (*domain.ContestDetail, error) {
-	contest, err := s.repo.CreateContest(args)
+	contest, err := s.repo.CreateContest(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (s *contestService) CreateContest(ctx context.Context, args *repository.Cre
 }
 
 func (s *contestService) UpdateContest(ctx context.Context, contestID uuid.UUID, args *repository.UpdateContestArgs) error {
-	err := s.repo.UpdateContest(contestID, args)
+	err := s.repo.UpdateContest(ctx, contestID, args)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (s *contestService) UpdateContest(ctx context.Context, contestID uuid.UUID,
 }
 
 func (s *contestService) DeleteContest(ctx context.Context, contestID uuid.UUID) error {
-	if err := s.repo.DeleteContest(contestID); err != nil {
+	if err := s.repo.DeleteContest(ctx, contestID); err != nil {
 		return err
 	}
 
@@ -90,7 +90,7 @@ func (s *contestService) DeleteContest(ctx context.Context, contestID uuid.UUID)
 }
 
 func (s *contestService) GetContestTeams(ctx context.Context, contestID uuid.UUID) ([]*domain.ContestTeam, error) {
-	contestTeams, err := s.repo.GetContestTeams(contestID)
+	contestTeams, err := s.repo.GetContestTeams(ctx, contestID)
 	if err != nil {
 		return nil, err
 	}
@@ -98,12 +98,12 @@ func (s *contestService) GetContestTeams(ctx context.Context, contestID uuid.UUI
 }
 
 func (s *contestService) GetContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) (*domain.ContestTeamDetail, error) {
-	contestTeam, err := s.repo.GetContestTeam(contestID, teamID)
+	contestTeam, err := s.repo.GetContestTeam(ctx, contestID, teamID)
 	if err != nil {
 		return nil, err
 	}
 
-	members, err := s.repo.GetContestTeamMembers(contestID, teamID)
+	members, err := s.repo.GetContestTeamMembers(ctx, contestID, teamID)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (s *contestService) GetContestTeam(ctx context.Context, contestID uuid.UUID
 }
 
 func (s *contestService) CreateContestTeam(ctx context.Context, contestID uuid.UUID, args *repository.CreateContestTeamArgs) (*domain.ContestTeamDetail, error) {
-	contestTeam, err := s.repo.CreateContestTeam(contestID, args)
+	contestTeam, err := s.repo.CreateContestTeam(ctx, contestID, args)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (s *contestService) CreateContestTeam(ctx context.Context, contestID uuid.U
 }
 
 func (s *contestService) UpdateContestTeam(ctx context.Context, teamID uuid.UUID, args *repository.UpdateContestTeamArgs) error {
-	if err := s.repo.UpdateContestTeam(teamID, args); err != nil {
+	if err := s.repo.UpdateContestTeam(ctx, teamID, args); err != nil {
 		return err
 	}
 
@@ -130,7 +130,7 @@ func (s *contestService) UpdateContestTeam(ctx context.Context, teamID uuid.UUID
 }
 
 func (s *contestService) DeleteContestTeam(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) error {
-	if err := s.repo.DeleteContestTeam(contestID, teamID); err != nil {
+	if err := s.repo.DeleteContestTeam(ctx, contestID, teamID); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (s *contestService) DeleteContestTeam(ctx context.Context, contestID uuid.U
 }
 
 func (s *contestService) GetContestTeamMembers(ctx context.Context, contestID uuid.UUID, teamID uuid.UUID) ([]*domain.User, error) {
-	members, err := s.repo.GetContestTeamMembers(contestID, teamID)
+	members, err := s.repo.GetContestTeamMembers(ctx, contestID, teamID)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (s *contestService) GetContestTeamMembers(ctx context.Context, contestID uu
 }
 
 func (s *contestService) AddContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error {
-	if err := s.repo.AddContestTeamMembers(teamID, memberIDs); err != nil {
+	if err := s.repo.AddContestTeamMembers(ctx, teamID, memberIDs); err != nil {
 		return err
 	}
 
@@ -155,7 +155,7 @@ func (s *contestService) AddContestTeamMembers(ctx context.Context, teamID uuid.
 }
 
 func (s *contestService) EditContestTeamMembers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID) error {
-	if err := s.repo.EditContestTeamMembers(teamID, memberIDs); err != nil {
+	if err := s.repo.EditContestTeamMembers(ctx, teamID, memberIDs); err != nil {
 		return err
 	}
 

--- a/usecases/service/contest_test.go
+++ b/usecases/service/contest_test.go
@@ -46,7 +46,7 @@ func TestContestService_GetContests(t *testing.T) {
 			},
 			setup: func(f fields, args args, want []*domain.Contest) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContests().Return(want, nil)
+				repo.EXPECT().GetContests(args.ctx).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -58,7 +58,7 @@ func TestContestService_GetContests(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want []*domain.Contest) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContests().Return(nil, repository.ErrForbidden)
+				repo.EXPECT().GetContests(args.ctx).Return(nil, repository.ErrForbidden)
 			},
 			assertion: assert.Error,
 		},
@@ -127,8 +127,8 @@ func TestContestService_GetContest(t *testing.T) {
 			},
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContest(args.id).Return(want, nil)
-				repo.EXPECT().GetContestTeams(args.id).Return(want.ContestTeams, nil)
+				repo.EXPECT().GetContest(args.ctx, args.id).Return(want, nil)
+				repo.EXPECT().GetContestTeams(args.ctx, args.id).Return(want.ContestTeams, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -151,8 +151,8 @@ func TestContestService_GetContest(t *testing.T) {
 			},
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContest(args.id).Return(want, nil)
-				repo.EXPECT().GetContestTeams(args.id).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContest(args.ctx, args.id).Return(want, nil)
+				repo.EXPECT().GetContestTeams(args.ctx, args.id).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.NoError,
 		},
@@ -165,7 +165,7 @@ func TestContestService_GetContest(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContest(args.id).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContest(args.ctx, args.id).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -178,8 +178,8 @@ func TestContestService_GetContest(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContest(args.id).Return(want, nil)
-				repo.EXPECT().GetContestTeams(args.id).Return(nil, repository.ErrInvalidID)
+				repo.EXPECT().GetContest(args.ctx, args.id).Return(want, nil)
+				repo.EXPECT().GetContestTeams(args.ctx, args.id).Return(nil, repository.ErrInvalidID)
 			},
 			assertion: assert.Error,
 		},
@@ -247,7 +247,7 @@ func TestContestService_CreateContest(t *testing.T) {
 			},
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().CreateContest(args.args).Return(want, nil)
+				repo.EXPECT().CreateContest(args.ctx, args.args).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -266,7 +266,7 @@ func TestContestService_CreateContest(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().CreateContest(args.args).Return(nil, repository.ErrInvalidArg)
+				repo.EXPECT().CreateContest(args.ctx, args.args).Return(nil, repository.ErrInvalidArg)
 			},
 			assertion: assert.Error,
 		},
@@ -322,7 +322,7 @@ func TestContestService_UpdateContest(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().UpdateContest(args.id, args.args).Return(nil)
+				repo.EXPECT().UpdateContest(args.ctx, args.id, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -341,7 +341,7 @@ func TestContestService_UpdateContest(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().UpdateContest(args.id, args.args).Return(repository.ErrNotFound)
+				repo.EXPECT().UpdateContest(args.ctx, args.id, args.args).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -387,7 +387,7 @@ func TestContestService_DeleteContest(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().DeleteContest(args.id).Return(nil)
+				repo.EXPECT().DeleteContest(args.ctx, args.id).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -399,7 +399,7 @@ func TestContestService_DeleteContest(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().DeleteContest(args.id).Return(repository.ErrNotFound)
+				repo.EXPECT().DeleteContest(args.ctx, args.id).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -456,7 +456,7 @@ func TestContestService_GetContestTeams(t *testing.T) {
 			},
 			setup: func(f fields, args args, want []*domain.ContestTeam) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeams(args.contestID).Return(want, nil)
+				repo.EXPECT().GetContestTeams(args.ctx, args.contestID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -469,7 +469,7 @@ func TestContestService_GetContestTeams(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want []*domain.ContestTeam) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeams(args.contestID).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContestTeams(args.ctx, args.contestID).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -536,7 +536,7 @@ func Test_contestService_GetContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args, want *domain.ContestTeamDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeam(args.contestID, args.teamID).Return(&domain.ContestTeamDetail{
+				repo.EXPECT().GetContestTeam(args.ctx, args.contestID, args.teamID).Return(&domain.ContestTeamDetail{
 					ContestTeam: domain.ContestTeam{
 						ID:        args.teamID,
 						ContestID: args.contestID,
@@ -546,7 +546,7 @@ func Test_contestService_GetContestTeam(t *testing.T) {
 					Link:        want.Link,
 					Description: want.Description,
 				}, nil)
-				repo.EXPECT().GetContestTeamMembers(args.contestID, args.teamID).Return(want.Members, nil)
+				repo.EXPECT().GetContestTeamMembers(args.ctx, args.contestID, args.teamID).Return(want.Members, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -560,7 +560,7 @@ func Test_contestService_GetContestTeam(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestTeamDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeam(args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContestTeam(args.ctx, args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -574,7 +574,7 @@ func Test_contestService_GetContestTeam(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestTeamDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeam(args.contestID, args.teamID).Return(&domain.ContestTeamDetail{
+				repo.EXPECT().GetContestTeam(args.ctx, args.contestID, args.teamID).Return(&domain.ContestTeamDetail{
 					ContestTeam: domain.ContestTeam{
 						ID:        args.teamID,
 						ContestID: args.contestID,
@@ -584,7 +584,7 @@ func Test_contestService_GetContestTeam(t *testing.T) {
 					Link:        random.RandURLString(),
 					Description: random.AlphaNumeric(),
 				}, nil)
-				repo.EXPECT().GetContestTeamMembers(args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContestTeamMembers(args.ctx, args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -660,7 +660,7 @@ func TestContestService_CreateContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args, want *domain.ContestTeamDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().CreateContestTeam(args.contestID, args.args).Return(&domain.ContestTeamDetail{
+				repo.EXPECT().CreateContestTeam(args.ctx, args.contestID, args.args).Return(&domain.ContestTeamDetail{
 					ContestTeam: domain.ContestTeam{
 						ID:        tid,
 						ContestID: args.contestID,
@@ -689,7 +689,7 @@ func TestContestService_CreateContestTeam(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.ContestTeamDetail) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().CreateContestTeam(args.contestID, args.args).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().CreateContestTeam(args.ctx, args.contestID, args.args).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -744,7 +744,7 @@ func TestContestService_UpdateContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().UpdateContestTeam(args.teamID, args.args).Return(nil)
+				repo.EXPECT().UpdateContestTeam(args.ctx, args.teamID, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -757,7 +757,7 @@ func TestContestService_UpdateContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().UpdateContestTeam(args.teamID, args.args).Return(nil)
+				repo.EXPECT().UpdateContestTeam(args.ctx, args.teamID, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -775,7 +775,7 @@ func TestContestService_UpdateContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().UpdateContestTeam(args.teamID, args.args).Return(repository.ErrNotFound)
+				repo.EXPECT().UpdateContestTeam(args.ctx, args.teamID, args.args).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -823,7 +823,7 @@ func Test_contestService_DeleteContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().DeleteContestTeam(args.contestID, args.teamID).Return(nil)
+				repo.EXPECT().DeleteContestTeam(args.ctx, args.contestID, args.teamID).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -836,7 +836,7 @@ func Test_contestService_DeleteContestTeam(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().DeleteContestTeam(args.contestID, args.teamID).Return(repository.ErrNotFound)
+				repo.EXPECT().DeleteContestTeam(args.ctx, args.contestID, args.teamID).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -888,7 +888,7 @@ func TestContestService_GetContestTeamMembers(t *testing.T) {
 			},
 			setup: func(f fields, args args, want []*domain.User) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeamMembers(args.contestID, args.teamID).Return(want, nil)
+				repo.EXPECT().GetContestTeamMembers(args.ctx, args.contestID, args.teamID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -902,7 +902,7 @@ func TestContestService_GetContestTeamMembers(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want []*domain.User) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().GetContestTeamMembers(args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetContestTeamMembers(args.ctx, args.contestID, args.teamID).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -952,7 +952,7 @@ func TestContestService_AddContestTeamMembers(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().AddContestTeamMembers(args.teamID, args.memberIDs).Return(nil)
+				repo.EXPECT().AddContestTeamMembers(args.ctx, args.teamID, args.memberIDs).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -965,7 +965,7 @@ func TestContestService_AddContestTeamMembers(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().AddContestTeamMembers(args.teamID, args.memberIDs).Return(repository.ErrNotFound)
+				repo.EXPECT().AddContestTeamMembers(args.ctx, args.teamID, args.memberIDs).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -1013,7 +1013,7 @@ func TestContestService_EditContestTeamMembers(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().EditContestTeamMembers(args.teamID, args.memberIDs).Return(nil)
+				repo.EXPECT().EditContestTeamMembers(args.ctx, args.teamID, args.memberIDs).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -1026,7 +1026,7 @@ func TestContestService_EditContestTeamMembers(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				repo := f.repo.(*mock_repository.MockContestRepository)
-				repo.EXPECT().EditContestTeamMembers(args.teamID, args.memberIDs).Return(repository.ErrNotFound)
+				repo.EXPECT().EditContestTeamMembers(args.ctx, args.teamID, args.memberIDs).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},

--- a/usecases/service/event.go
+++ b/usecases/service/event.go
@@ -26,17 +26,17 @@ func NewEventService(event repository.EventRepository, user repository.UserRepos
 }
 
 func (s *eventService) GetEvents(ctx context.Context) ([]*domain.Event, error) {
-	return s.event.GetEvents()
+	return s.event.GetEvents(ctx)
 }
 
 func (s *eventService) GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.EventDetail, error) {
-	event, err := s.event.GetEvent(eventID)
+	event, err := s.event.GetEvent(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}
 
 	// hostnameの詳細を取得
-	users, err := s.user.GetUsers(&repository.GetUsersArgs{}) // TODO: IncludeSuspendedをtrueにするか考える
+	users, err := s.user.GetUsers(ctx, &repository.GetUsersArgs{}) // TODO: IncludeSuspendedをtrueにするか考える
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s *eventService) GetEventByID(ctx context.Context, eventID uuid.UUID) (*do
 }
 
 func (s *eventService) UpdateEventLevel(ctx context.Context, eventID uuid.UUID, arg *repository.UpdateEventLevelArgs) error {
-	return s.event.UpdateEventLevel(eventID, arg)
+	return s.event.UpdateEventLevel(ctx, eventID, arg)
 }
 
 // Interface guards

--- a/usecases/service/event_test.go
+++ b/usecases/service/event_test.go
@@ -48,7 +48,7 @@ func TestEventService_GetEvents(t *testing.T) {
 			},
 			setup: func(f fields, args args, want []*domain.Event) {
 				e := f.event.(*mock_repository.MockEventRepository)
-				e.EXPECT().GetEvents().Return(want, nil)
+				e.EXPECT().GetEvents(args.ctx).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -117,7 +117,7 @@ func TestEventService_GetEventByID(t *testing.T) {
 				want.ID = args.id
 				e := f.event.(*mock_repository.MockEventRepository)
 				u := f.user.(*mock_repository.MockUserRepository)
-				e.EXPECT().GetEvent(args.id).Return(&domain.EventDetail{
+				e.EXPECT().GetEvent(args.ctx, args.id).Return(&domain.EventDetail{
 					Event: domain.Event{
 						ID:        args.id,
 						Name:      want.Name,
@@ -131,7 +131,7 @@ func TestEventService_GetEventByID(t *testing.T) {
 					GroupID:     want.GroupID,
 					RoomID:      want.RoomID,
 				}, nil)
-				u.EXPECT().GetUsers(&repository.GetUsersArgs{}).Return(want.HostName, nil)
+				u.EXPECT().GetUsers(args.ctx, &repository.GetUsersArgs{}).Return(want.HostName, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -144,7 +144,7 @@ func TestEventService_GetEventByID(t *testing.T) {
 			want: nil,
 			setup: func(f fields, args args, want *domain.EventDetail) {
 				e := f.event.(*mock_repository.MockEventRepository)
-				e.EXPECT().GetEvent(args.id).Return(nil, repository.ErrForbidden)
+				e.EXPECT().GetEvent(args.ctx, args.id).Return(nil, repository.ErrForbidden)
 			},
 			assertion: assert.Error,
 		},
@@ -158,7 +158,7 @@ func TestEventService_GetEventByID(t *testing.T) {
 			setup: func(f fields, args args, want *domain.EventDetail) {
 				e := f.event.(*mock_repository.MockEventRepository)
 				u := f.user.(*mock_repository.MockUserRepository)
-				e.EXPECT().GetEvent(args.id).Return(&domain.EventDetail{
+				e.EXPECT().GetEvent(args.ctx, args.id).Return(&domain.EventDetail{
 					Event: domain.Event{
 						ID:        args.id,
 						Name:      random.AlphaNumeric(),
@@ -172,7 +172,7 @@ func TestEventService_GetEventByID(t *testing.T) {
 					GroupID:     random.UUID(),
 					RoomID:      random.UUID(),
 				}, nil)
-				u.EXPECT().GetUsers(&repository.GetUsersArgs{}).Return(nil, repository.ErrForbidden)
+				u.EXPECT().GetUsers(args.ctx, &repository.GetUsersArgs{}).Return(nil, repository.ErrForbidden)
 			},
 			assertion: assert.Error,
 		},
@@ -226,7 +226,7 @@ func TestEventService_UpdateEvent(t *testing.T) {
 			},
 			setup: func(f fields, args args) {
 				e := f.event.(*mock_repository.MockEventRepository)
-				e.EXPECT().UpdateEventLevel(args.id, args.arg).Return(nil)
+				e.EXPECT().UpdateEventLevel(args.ctx, args.id, args.arg).Return(nil)
 			},
 			assertion: assert.NoError,
 		},

--- a/usecases/service/group.go
+++ b/usecases/service/group.go
@@ -27,17 +27,17 @@ func NewGroupService(group repository.GroupRepository, user repository.UserRepos
 }
 
 func (s *groupService) GetAllGroups(ctx context.Context) ([]*domain.Group, error) {
-	return s.group.GetAllGroups()
+	return s.group.GetAllGroups(ctx)
 }
 
 func (s *groupService) GetGroup(ctx context.Context, groupID uuid.UUID) (*domain.GroupDetail, error) {
-	groups, err := s.group.GetGroup(groupID)
+	groups, err := s.group.GetGroup(ctx, groupID)
 	if err != nil {
 		return nil, err
 	}
 
 	// pick all users info
-	users, err := s.user.GetUsers(&repository.GetUsersArgs{}) // TODO: IncludeSuspendedをtrueにするか考える
+	users, err := s.user.GetUsers(ctx, &repository.GetUsersArgs{}) // TODO: IncludeSuspendedをtrueにするか考える
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/service/group_test.go
+++ b/usecases/service/group_test.go
@@ -36,7 +36,7 @@ func TestGroupService_GetAllGroups(t *testing.T) {
 				},
 			},
 			setup: func(group *mock_repository.MockGroupRepository, user *mock_repository.MockUserRepository, args args, want []*domain.Group) {
-				group.EXPECT().GetAllGroups().Return(want, nil)
+				group.EXPECT().GetAllGroups(args.ctx).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -97,7 +97,7 @@ func TestGroupService_GetGroup(t *testing.T) {
 				Description: random.AlphaNumeric(),
 			},
 			setup: func(group *mock_repository.MockGroupRepository, user *mock_repository.MockUserRepository, args args, want *domain.GroupDetail) {
-				group.EXPECT().GetGroup(groupID).Return(&domain.GroupDetail{
+				group.EXPECT().GetGroup(args.ctx, groupID).Return(&domain.GroupDetail{
 					ID:   groupID,
 					Name: want.Name,
 					Link: want.Link,
@@ -116,7 +116,7 @@ func TestGroupService_GetGroup(t *testing.T) {
 					},
 					Description: want.Description,
 				}, nil)
-				user.EXPECT().GetUsers(&repository.GetUsersArgs{}).Return([]*domain.User{
+				user.EXPECT().GetUsers(args.ctx, &repository.GetUsersArgs{}).Return([]*domain.User{
 					want.Admin[0],
 					&want.Members[0].User,
 				}, nil)

--- a/usecases/service/mock_service/mock_user.go
+++ b/usecases/service/mock_service/mock_user.go
@@ -81,33 +81,33 @@ func (mr *MockUserServiceMockRecorder) EditAccount(ctx, userID, accountID, args 
 }
 
 // GetAccount mocks base method.
-func (m *MockUserService) GetAccount(userID, accountID uuid.UUID) (*domain.Account, error) {
+func (m *MockUserService) GetAccount(ctx context.Context, userID, accountID uuid.UUID) (*domain.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccount", userID, accountID)
+	ret := m.ctrl.Call(m, "GetAccount", ctx, userID, accountID)
 	ret0, _ := ret[0].(*domain.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAccount indicates an expected call of GetAccount.
-func (mr *MockUserServiceMockRecorder) GetAccount(userID, accountID interface{}) *gomock.Call {
+func (mr *MockUserServiceMockRecorder) GetAccount(ctx, userID, accountID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockUserService)(nil).GetAccount), userID, accountID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockUserService)(nil).GetAccount), ctx, userID, accountID)
 }
 
 // GetAccounts mocks base method.
-func (m *MockUserService) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
+func (m *MockUserService) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccounts", userID)
+	ret := m.ctrl.Call(m, "GetAccounts", ctx, userID)
 	ret0, _ := ret[0].([]*domain.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAccounts indicates an expected call of GetAccounts.
-func (mr *MockUserServiceMockRecorder) GetAccounts(userID interface{}) *gomock.Call {
+func (mr *MockUserServiceMockRecorder) GetAccounts(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccounts", reflect.TypeOf((*MockUserService)(nil).GetAccounts), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccounts", reflect.TypeOf((*MockUserService)(nil).GetAccounts), ctx, userID)
 }
 
 // GetGroupsByUserID mocks base method.

--- a/usecases/service/project.go
+++ b/usecases/service/project.go
@@ -31,7 +31,7 @@ func NewProjectService(projectRepository repository.ProjectRepository) ProjectSe
 }
 
 func (s *projectService) GetProjects(ctx context.Context) ([]*domain.Project, error) {
-	res, err := s.repo.GetProjects()
+	res, err := s.repo.GetProjects(ctx, )
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (s *projectService) GetProjects(ctx context.Context) ([]*domain.Project, er
 }
 
 func (s *projectService) GetProject(ctx context.Context, projectID uuid.UUID) (*domain.ProjectDetail, error) {
-	project, err := s.repo.GetProject(projectID)
+	project, err := s.repo.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (s *projectService) CreateProject(ctx context.Context, args *repository.Cre
 		return nil, repository.ErrInvalidArg
 	}
 
-	res, err := s.repo.CreateProject(args)
+	res, err := s.repo.CreateProject(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (s *projectService) CreateProject(ctx context.Context, args *repository.Cre
 }
 
 func (s *projectService) UpdateProject(ctx context.Context, projectID uuid.UUID, args *repository.UpdateProjectArgs) error {
-	old, err := s.repo.GetProject(projectID)
+	old, err := s.repo.GetProject(ctx, projectID)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (s *projectService) UpdateProject(ctx context.Context, projectID uuid.UUID,
 		return repository.ErrInvalidArg
 	}
 
-	if err := s.repo.UpdateProject(projectID, args); err != nil {
+	if err := s.repo.UpdateProject(ctx, projectID, args); err != nil {
 		return err
 	}
 
@@ -90,7 +90,7 @@ func (s *projectService) UpdateProject(ctx context.Context, projectID uuid.UUID,
 }
 
 func (s *projectService) GetProjectMembers(ctx context.Context, projectID uuid.UUID) ([]*domain.UserWithDuration, error) {
-	members, err := s.repo.GetProjectMembers(projectID)
+	members, err := s.repo.GetProjectMembers(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (s *projectService) AddProjectMembers(ctx context.Context, projectID uuid.U
 		}
 	}
 
-	err := s.repo.AddProjectMembers(projectID, args)
+	err := s.repo.AddProjectMembers(ctx, projectID, args)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (s *projectService) AddProjectMembers(ctx context.Context, projectID uuid.U
 }
 
 func (s *projectService) DeleteProjectMembers(ctx context.Context, projectID uuid.UUID, memberIDs []uuid.UUID) error {
-	err := s.repo.DeleteProjectMembers(projectID, memberIDs)
+	err := s.repo.DeleteProjectMembers(ctx, projectID, memberIDs)
 	if err != nil {
 		return err
 	}

--- a/usecases/service/project.go
+++ b/usecases/service/project.go
@@ -31,7 +31,7 @@ func NewProjectService(projectRepository repository.ProjectRepository) ProjectSe
 }
 
 func (s *projectService) GetProjects(ctx context.Context) ([]*domain.Project, error) {
-	res, err := s.repo.GetProjects(ctx, )
+	res, err := s.repo.GetProjects(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/service/project_test.go
+++ b/usecases/service/project_test.go
@@ -39,7 +39,7 @@ func TestProjectService_GetProjects(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want []*domain.Project) {
-				repo.EXPECT().GetProjects().Return(want, nil)
+				repo.EXPECT().GetProjects(args.ctx).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -48,7 +48,7 @@ func TestProjectService_GetProjects(t *testing.T) {
 			args: args{ctx: context.Background()},
 			want: nil,
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want []*domain.Project) {
-				repo.EXPECT().GetProjects().Return(nil, gorm.ErrInvalidDB)
+				repo.EXPECT().GetProjects(args.ctx).Return(nil, gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -106,7 +106,7 @@ func TestProjectService_GetProject(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want *domain.ProjectDetail) {
-				repo.EXPECT().GetProject(args.id).Return(want, nil)
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -118,7 +118,7 @@ func TestProjectService_GetProject(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want *domain.ProjectDetail) {
-				repo.EXPECT().GetProject(args.id).Return(nil, gorm.ErrInvalidDB)
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(nil, gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -188,7 +188,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 				if args.args.Link.Valid {
 					want.Link = args.args.Link.String
 				}
-				repo.EXPECT().CreateProject(gomock.Any()).Return(want, nil) // TODO: CreateProject内でuuid.NewV4するのでテストができない？
+				repo.EXPECT().CreateProject(args.ctx, gomock.Any()).Return(want, nil) // TODO: CreateProject内でuuid.NewV4するのでテストができない？
 			},
 			assertion: assert.NoError,
 		},
@@ -227,7 +227,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want *domain.ProjectDetail) {
-				repo.EXPECT().CreateProject(args.args).Return(nil, gorm.ErrInvalidDB)
+				repo.EXPECT().CreateProject(args.ctx, args.args).Return(nil, gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -281,13 +281,13 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().GetProject(args.id).Return(&domain.ProjectDetail{
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(&domain.ProjectDetail{
 					Project: domain.Project{
 						ID:       args.id,
 						Duration: duration,
 					},
 				}, nil)
-				repo.EXPECT().UpdateProject(args.id, args.args).Return(nil)
+				repo.EXPECT().UpdateProject(args.ctx, args.id, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -299,7 +299,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				args: nil,
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().GetProject(args.id).Return(nil, repository.ErrNotFound)
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(nil, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -319,7 +319,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().GetProject(args.id).Return(&domain.ProjectDetail{
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(&domain.ProjectDetail{
 					Project: domain.Project{
 						ID:       args.id,
 						Duration: duration,
@@ -344,13 +344,13 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().GetProject(args.id).Return(&domain.ProjectDetail{
+				repo.EXPECT().GetProject(args.ctx, args.id).Return(&domain.ProjectDetail{
 					Project: domain.Project{
 						ID:       args.id,
 						Duration: duration,
 					},
 				}, nil)
-				repo.EXPECT().UpdateProject(args.id, args.args).Return(gorm.ErrInvalidDB)
+				repo.EXPECT().UpdateProject(args.ctx, args.id, args.args).Return(gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -397,7 +397,7 @@ func TestProjectService_GetProjectMembers(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want []*domain.UserWithDuration) {
-				repo.EXPECT().GetProjectMembers(args.id).Return(want, nil)
+				repo.EXPECT().GetProjectMembers(args.ctx, args.id).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -409,7 +409,7 @@ func TestProjectService_GetProjectMembers(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockProjectRepository, args args, want []*domain.UserWithDuration) {
-				repo.EXPECT().GetProjectMembers(args.id).Return(nil, gorm.ErrInvalidDB)
+				repo.EXPECT().GetProjectMembers(args.ctx, args.id).Return(nil, gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -463,7 +463,7 @@ func TestProjectService_AddProjectMembers(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().AddProjectMembers(args.projectID, args.args).Return(nil)
+				repo.EXPECT().AddProjectMembers(args.ctx, args.projectID, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -502,7 +502,7 @@ func TestProjectService_AddProjectMembers(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().AddProjectMembers(args.projectID, args.args).Return(gorm.ErrInvalidDB)
+				repo.EXPECT().AddProjectMembers(args.ctx, args.projectID, args.args).Return(gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},
@@ -545,7 +545,7 @@ func TestProjectService_DeleteProjectMembers(t *testing.T) {
 				memberIDs: []uuid.UUID{random.UUID()},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().DeleteProjectMembers(args.projectID, args.memberIDs).Return(nil)
+				repo.EXPECT().DeleteProjectMembers(args.ctx, args.projectID, args.memberIDs).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -557,7 +557,7 @@ func TestProjectService_DeleteProjectMembers(t *testing.T) {
 				memberIDs: []uuid.UUID{random.UUID()},
 			},
 			setup: func(repo *mock_repository.MockProjectRepository, args args) {
-				repo.EXPECT().DeleteProjectMembers(args.projectID, args.memberIDs).Return(gorm.ErrInvalidDB)
+				repo.EXPECT().DeleteProjectMembers(args.ctx, args.projectID, args.memberIDs).Return(gorm.ErrInvalidDB)
 			},
 			assertion: assert.Error,
 		},

--- a/usecases/service/user.go
+++ b/usecases/service/user.go
@@ -14,8 +14,8 @@ type UserService interface {
 	GetUsers(ctx context.Context, args *repository.GetUsersArgs) ([]*domain.User, error)
 	GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error)
 	Update(ctx context.Context, userID uuid.UUID, args *repository.UpdateUserArgs) error
-	GetAccount(userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error)
-	GetAccounts(userID uuid.UUID) ([]*domain.Account, error)
+	GetAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error)
+	GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error)
 	CreateAccount(ctx context.Context, userID uuid.UUID, account *repository.CreateAccountArgs) (*domain.Account, error)
 	EditAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error
 	DeleteAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) error
@@ -35,7 +35,7 @@ func NewUserService(userRepository repository.UserRepository, eventRepository re
 }
 
 func (s *userService) GetUsers(ctx context.Context, args *repository.GetUsersArgs) ([]*domain.User, error) {
-	users, err := s.repo.GetUsers(args)
+	users, err := s.repo.GetUsers(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (s *userService) GetUsers(ctx context.Context, args *repository.GetUsersArg
 }
 
 func (s *userService) GetUser(ctx context.Context, userID uuid.UUID) (*domain.UserDetail, error) {
-	user, err := s.repo.GetUser(userID)
+	user, err := s.repo.GetUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,27 +51,27 @@ func (s *userService) GetUser(ctx context.Context, userID uuid.UUID) (*domain.Us
 }
 
 func (s *userService) Update(ctx context.Context, userID uuid.UUID, args *repository.UpdateUserArgs) error {
-	if err := s.repo.UpdateUser(userID, args); err != nil {
+	if err := s.repo.UpdateUser(ctx, userID, args); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (s *userService) GetAccount(userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
-	return s.repo.GetAccount(userID, accountID)
+func (s *userService) GetAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID) (*domain.Account, error) {
+	return s.repo.GetAccount(ctx, userID, accountID)
 }
 
-func (s *userService) GetAccounts(userID uuid.UUID) ([]*domain.Account, error) {
-	return s.repo.GetAccounts(userID)
+func (s *userService) GetAccounts(ctx context.Context, userID uuid.UUID) ([]*domain.Account, error) {
+	return s.repo.GetAccounts(ctx, userID)
 }
 
 func (s *userService) CreateAccount(ctx context.Context, userID uuid.UUID, account *repository.CreateAccountArgs) (*domain.Account, error) {
-	return s.repo.CreateAccount(userID, account)
+	return s.repo.CreateAccount(ctx, userID, account)
 }
 
 func (s *userService) EditAccount(ctx context.Context, userID uuid.UUID, accountID uuid.UUID, args *repository.UpdateAccountArgs) error {
-	if err := s.repo.UpdateAccount(userID, accountID, args); err != nil {
+	if err := s.repo.UpdateAccount(ctx, userID, accountID, args); err != nil {
 		return err
 	}
 
@@ -83,14 +83,14 @@ func (s *userService) DeleteAccount(ctx context.Context, userID uuid.UUID, accou
 	//TODO
 	/*userのaccount.type番目のアカウントを削除する処理をしたい*/
 
-	err := s.repo.DeleteAccount(userID, accountID)
+	err := s.repo.DeleteAccount(ctx, userID, accountID)
 
 	return err
 
 }
 
 func (s *userService) GetUserProjects(ctx context.Context, userID uuid.UUID) ([]*domain.UserProject, error) {
-	projects, err := s.repo.GetProjects(userID)
+	projects, err := s.repo.GetProjects(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (s *userService) GetUserProjects(ctx context.Context, userID uuid.UUID) ([]
 }
 
 func (s *userService) GetUserContests(ctx context.Context, userID uuid.UUID) ([]*domain.UserContest, error) {
-	contests, err := s.repo.GetContests(userID)
+	contests, err := s.repo.GetContests(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (s *userService) GetUserContests(ctx context.Context, userID uuid.UUID) ([]
 }
 
 func (s *userService) GetGroupsByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.UserGroup, error) {
-	groups, err := s.repo.GetGroupsByUserID(userID)
+	groups, err := s.repo.GetGroupsByUserID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (s *userService) GetGroupsByUserID(ctx context.Context, userID uuid.UUID) (
 }
 
 func (s *userService) GetUserEvents(ctx context.Context, userID uuid.UUID) ([]*domain.Event, error) {
-	events, err := s.event.GetUserEvents(userID)
+	events, err := s.event.GetUserEvents(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/service/user_test.go
+++ b/usecases/service/user_test.go
@@ -38,7 +38,7 @@ func TestUserService_GetUsers(t *testing.T) {
 				domain.NewUser(random.UUID(), random.AlphaNumeric(), random.AlphaNumeric(), random.Bool()),
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.User) {
-				repo.EXPECT().GetUsers(args.args).Return(want, nil)
+				repo.EXPECT().GetUsers(args.ctx, args.args).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -50,7 +50,7 @@ func TestUserService_GetUsers(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.User) {
-				repo.EXPECT().GetUsers(args.args).Return(want, repository.ErrForbidden)
+				repo.EXPECT().GetUsers(args.ctx, args.args).Return(want, repository.ErrForbidden)
 			},
 			assertion: assert.Error,
 		},
@@ -108,7 +108,7 @@ func TestUserService_GetUser(t *testing.T) {
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want *domain.UserDetail) {
 				want.ID = args.id
-				repo.EXPECT().GetUser(args.id).Return(want, nil)
+				repo.EXPECT().GetUser(args.ctx, args.id).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -120,7 +120,7 @@ func TestUserService_GetUser(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want *domain.UserDetail) {
-				repo.EXPECT().GetUser(args.id).Return(nil, repository.ErrForbidden)
+				repo.EXPECT().GetUser(args.ctx, args.id).Return(nil, repository.ErrForbidden)
 			},
 			assertion: assert.Error,
 		},
@@ -168,7 +168,7 @@ func TestUserService_Update(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args) {
-				repo.EXPECT().UpdateUser(args.id, args.args).Return(nil)
+				repo.EXPECT().UpdateUser(args.ctx, args.id, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -183,7 +183,7 @@ func TestUserService_Update(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args) {
-				repo.EXPECT().UpdateUser(args.id, args.args).Return(repository.ErrNotFound)
+				repo.EXPECT().UpdateUser(args.ctx, args.id, args.args).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -208,6 +208,7 @@ func TestUserService_Update(t *testing.T) {
 func TestUserService_GetAccount(t *testing.T) {
 	t.Parallel()
 	type args struct {
+		ctx       context.Context
 		userID    uuid.UUID
 		accountID uuid.UUID
 	}
@@ -221,6 +222,7 @@ func TestUserService_GetAccount(t *testing.T) {
 		{
 			name: "Success",
 			args: args{
+				ctx:       context.Background(),
 				userID:    random.UUID(),
 				accountID: random.UUID(),
 			},
@@ -231,7 +233,7 @@ func TestUserService_GetAccount(t *testing.T) {
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want *domain.Account) {
 				want.ID = args.accountID
-				repo.EXPECT().GetAccount(args.userID, args.accountID).Return(want, nil)
+				repo.EXPECT().GetAccount(args.ctx, args.userID, args.accountID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -248,7 +250,7 @@ func TestUserService_GetAccount(t *testing.T) {
 			tt.setup(repo, event, tt.args, tt.want)
 
 			s := NewUserService(repo, event)
-			got, err := s.GetAccount(tt.args.userID, tt.args.accountID)
+			got, err := s.GetAccount(tt.args.ctx, tt.args.userID, tt.args.accountID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -258,6 +260,7 @@ func TestUserService_GetAccount(t *testing.T) {
 func TestUserService_GetAccounts(t *testing.T) {
 	t.Parallel()
 	type args struct {
+		ctx    context.Context
 		userID uuid.UUID
 	}
 	tests := []struct {
@@ -269,7 +272,10 @@ func TestUserService_GetAccounts(t *testing.T) {
 	}{
 		{
 			name: "Success",
-			args: args{userID: random.UUID()},
+			args: args{
+				ctx:    context.Background(),
+				userID: random.UUID(),
+			},
 			want: []*domain.Account{
 				{
 					ID:          random.UUID(),
@@ -278,7 +284,7 @@ func TestUserService_GetAccounts(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.Account) {
-				repo.EXPECT().GetAccounts(args.userID).Return(want, nil)
+				repo.EXPECT().GetAccounts(args.ctx, args.userID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -295,7 +301,7 @@ func TestUserService_GetAccounts(t *testing.T) {
 			tt.setup(repo, event, tt.args, tt.want)
 
 			s := NewUserService(repo, event)
-			got, err := s.GetAccounts(tt.args.userID)
+			got, err := s.GetAccounts(tt.args.ctx, tt.args.userID)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -334,7 +340,7 @@ func TestUserService_CreateAccount(t *testing.T) {
 				PrPermitted: true,
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want *domain.Account) {
-				repo.EXPECT().CreateAccount(args.id, args.account).Return(want, nil)
+				repo.EXPECT().CreateAccount(args.ctx, args.id, args.account).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -386,7 +392,7 @@ func TestUserService_EditAccount(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args) {
-				repo.EXPECT().UpdateAccount(args.userID, args.accountID, args.args).Return(nil)
+				repo.EXPECT().UpdateAccount(args.ctx, args.userID, args.accountID, args.args).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -404,7 +410,7 @@ func TestUserService_EditAccount(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args) {
-				repo.EXPECT().UpdateAccount(args.userID, args.accountID, args.args).Return(repository.ErrNotFound)
+				repo.EXPECT().UpdateAccount(args.ctx, args.userID, args.accountID, args.args).Return(repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -447,7 +453,7 @@ func TestUserService_DeleteAccount(t *testing.T) {
 				accountID: random.UUID(),
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args) {
-				repo.EXPECT().DeleteAccount(args.userID, args.accountID).Return(nil)
+				repo.EXPECT().DeleteAccount(args.ctx, args.userID, args.accountID).Return(nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -497,7 +503,7 @@ func TestUserService_GetUserProjects(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserProject) {
-				repo.EXPECT().GetProjects(args.userID).Return(want, nil)
+				repo.EXPECT().GetProjects(args.ctx, args.userID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -509,7 +515,7 @@ func TestUserService_GetUserProjects(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserProject) {
-				repo.EXPECT().GetProjects(args.userID).Return(want, repository.ErrNotFound)
+				repo.EXPECT().GetProjects(args.ctx, args.userID).Return(want, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -568,7 +574,7 @@ func TestUserService_GetUserContests(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserContest) {
-				repo.EXPECT().GetContests(args.userID).Return(want, nil)
+				repo.EXPECT().GetContests(args.ctx, args.userID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -580,7 +586,7 @@ func TestUserService_GetUserContests(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserContest) {
-				repo.EXPECT().GetContests(args.userID).Return(want, repository.ErrNotFound)
+				repo.EXPECT().GetContests(args.ctx, args.userID).Return(want, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -631,7 +637,7 @@ func TestUserService_GetGroupsByUserID(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserGroup) {
-				repo.EXPECT().GetGroupsByUserID(args.userID).Return(want, nil)
+				repo.EXPECT().GetGroupsByUserID(args.ctx, args.userID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -643,7 +649,7 @@ func TestUserService_GetGroupsByUserID(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.UserGroup) {
-				repo.EXPECT().GetGroupsByUserID(args.userID).Return(want, repository.ErrNotFound)
+				repo.EXPECT().GetGroupsByUserID(args.ctx, args.userID).Return(want, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},
@@ -694,7 +700,7 @@ func TestUserService_GetUserEvents(t *testing.T) {
 				},
 			},
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.Event) {
-				event.EXPECT().GetUserEvents(args.userID).Return(want, nil)
+				event.EXPECT().GetUserEvents(args.ctx, args.userID).Return(want, nil)
 			},
 			assertion: assert.NoError,
 		},
@@ -706,7 +712,7 @@ func TestUserService_GetUserEvents(t *testing.T) {
 			},
 			want: nil,
 			setup: func(repo *mock_repository.MockUserRepository, event *mock_repository.MockEventRepository, args args, want []*domain.Event) {
-				event.EXPECT().GetUserEvents(args.userID).Return(want, repository.ErrNotFound)
+				event.EXPECT().GetUserEvents(args.ctx, args.userID).Return(want, repository.ErrNotFound)
 			},
 			assertion: assert.Error,
 		},


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio/issues/244

- :sparkles: add WithContext method to interface database.SQLHandler
- :boom: add ctx to repository methods' args & use WithContext(ctx)
- :adhesive_bandage: format code
