### PR TITLE
configのリファクタ

### DIFF
--- a/infrastructure/wire.go
+++ b/infrastructure/wire.go
@@ -65,7 +65,7 @@ var confSet = wire.NewSet(
 	providePortalConf,
 )
 
-func provideIsDevelopMent(c *config.Config) bool              { return c.IsDevelopment() }
+func provideIsDevelopMent(c *config.Config) bool              { return !c.IsProduction }
 func provideTraqConf(c *config.Config) *config.TraqConfig     { return c.TraqConf() }
 func provideKnoqConf(c *config.Config) *config.KnoqConfig     { return c.KnoqConf() }
 func providePortalConf(c *config.Config) *config.PortalConfig { return c.PortalConf() }

--- a/infrastructure/wire_gen.go
+++ b/infrastructure/wire_gen.go
@@ -88,7 +88,7 @@ var confSet = wire.NewSet(
 	providePortalConf,
 )
 
-func provideIsDevelopMent(c *config.Config) bool { return c.IsDevelopment() }
+func provideIsDevelopMent(c *config.Config) bool { return !c.IsProduction }
 
 func provideTraqConf(c *config.Config) *config.TraqConfig { return c.TraqConf() }
 

--- a/integration_tests/handler/handler_test.go
+++ b/integration_tests/handler/handler_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testutils.ParseConfig("../testdata")
+	if err := testutils.ParseConfig("../testdata"); err != nil {
+		panic(err)
+	}
 
 	m.Run()
 }

--- a/integration_tests/repository/testutil_db_test.go
+++ b/integration_tests/repository/testutil_db_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/traPtitech/traPortfolio/domain"
 	"github.com/traPtitech/traPortfolio/integration_tests/testutils"
 	"github.com/traPtitech/traPortfolio/usecases/repository"
+	"github.com/traPtitech/traPortfolio/util/config"
 	"github.com/traPtitech/traPortfolio/util/optional"
 	"github.com/traPtitech/traPortfolio/util/random"
 )
@@ -19,7 +20,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	appConf := testutils.GetConfig()
+	appConf := config.Load()
 	sqlConf := appConf.SQLConf()
 	<-testutils.WaitTestDBConnection(sqlConf)
 

--- a/integration_tests/repository/testutil_db_test.go
+++ b/integration_tests/repository/testutil_db_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testutils.ParseConfig("../testdata")
+	if err := testutils.ParseConfig("../testdata"); err != nil {
+		panic(err)
+	}
 
 	appConf := testutils.GetConfig()
 	sqlConf := appConf.SQLConf()

--- a/integration_tests/testutils/config.go
+++ b/integration_tests/testutils/config.go
@@ -10,16 +10,8 @@ func ParseConfig(path string) error {
 	return config.ReadFromFile()
 }
 
-func GetConfig() *config.Config {
-	return config.GetConfig()
-}
-
-func GetModified(f config.EditFunc) *config.Config {
-	return config.GetModified(f)
-}
-
 func GetConfigWithDBName(dbName string) *config.Config {
-	return GetModified(func(c *config.Config) {
+	return config.Load(func(c *config.Config) {
 		c.DB.Name = testDBName(dbName)
 	})
 }

--- a/integration_tests/testutils/config.go
+++ b/integration_tests/testutils/config.go
@@ -5,9 +5,9 @@ import (
 	"github.com/traPtitech/traPortfolio/util/config"
 )
 
-func ParseConfig(path string) {
+func ParseConfig(path string) error {
 	viper.AddConfigPath(path)
-	config.ReadFromFile()
+	return config.ReadFromFile()
 }
 
 func GetConfig() *config.Config {

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -48,7 +48,7 @@ func establishTestDBConnection(t *testing.T, sqlConf *config.SQLConfig) *gorm.DB
 	conn, err := sql.Open("mysql", dbDsn)
 	assert.NoError(t, err)
 	defer conn.Close()
-	_, err = conn.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", sqlConf.DBName()))
+	_, err = conn.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", sqlConf.Name))
 	assert.NoError(t, err)
 
 	dsn := sqlConf.Dsn()

--- a/main.go
+++ b/main.go
@@ -21,13 +21,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if appConf.IsOnlyMigrate() {
+	if appConf.OnlyMigrate {
 		log.Println("migration finished")
 		return
 	}
 
-	if appConf.InsertMock() {
-		if !appConf.IsDevelopment() {
+	if appConf.InsertMockData {
+		if appConf.IsProduction {
 			log.Fatal("cannot specify both `production` and `insert-mock-data`")
 		}
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	appConf := config.GetConfig()
+	appConf := config.Load()
 	db, err := infrastructure.NewGormDB(appConf.SQLConf())
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,9 @@ import (
 )
 
 func main() {
-	config.Parse()
+	if err := config.Parse(); err != nil {
+		log.Fatal(err)
+	}
 
 	appConf := config.GetConfig()
 	db, err := infrastructure.NewGormDB(appConf.SQLConf())

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -149,20 +149,8 @@ func (c *Config) clone() *Config {
 	return &cloned
 }
 
-func (c *Config) IsDevelopment() bool {
-	return !c.IsProduction
-}
-
 func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
-}
-
-func (c *Config) IsOnlyMigrate() bool {
-	return c.OnlyMigrate
-}
-
-func (c *Config) InsertMock() bool {
-	return c.InsertMockData
 }
 
 func (c *Config) SQLConf() *SQLConfig {
@@ -199,10 +187,6 @@ func (c *SQLConfig) Dsn() string {
 
 func (c *SQLConfig) DsnWithoutName() string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&parseTime=True&collation=utf8mb4_general_ci", c.User, c.Pass, c.Host, c.Port)
-}
-
-func (c *SQLConfig) DBName() string {
-	return c.Name
 }
 
 func (c *SQLConfig) GormConfig() *gorm.Config {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -15,12 +15,6 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-const (
-	defaultAppPort = 1323
-	defaultDBPort  = 3306
-	defaultDBHost  = "127.0.0.1"
-)
-
 var (
 	config Config
 	parsed bool
@@ -66,15 +60,15 @@ type (
 
 func init() {
 	pflag.Bool("production", false, "whether production or development")
-	pflag.Int("port", defaultAppPort, "api port")
+	pflag.Int("port", 1323, "api port")
 	pflag.Bool("only-migrate", false, "only migrate db (not start server)")
 	pflag.Bool("insert-mock-data", false, "insert sample mock data(for dev)")
 
 	pflag.String("db-user", "", "db user name")
 	pflag.String("db-pass", "", "db password")
-	pflag.String("db-host", defaultDBHost, "db host")
+	pflag.String("db-host", "127.0.0.1", "db host")
 	pflag.String("db-name", "", "db name")
-	pflag.Int("db-port", defaultDBPort, "db port")
+	pflag.Int("db-port", 3306, "db port")
 	pflag.Bool("db-verbose", false, "db verbose mode")
 	pflag.String("traq-cookie", "", "traq cookie")
 	pflag.String("traq-api-endpoint", "", "traq api endpoint")

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -92,24 +92,6 @@ func Parse() {
 }
 
 func ReadFromFile() {
-	_ = viper.BindPFlag("production", pflag.Lookup("isProduction"))
-	_ = viper.BindPFlag("port", pflag.Lookup("port"))
-	_ = viper.BindPFlag("onlyMigrate", pflag.Lookup("only-migrate"))
-	_ = viper.BindPFlag("insertMockData", pflag.Lookup("insert-mock-data"))
-
-	_ = viper.BindPFlag("db.user", pflag.Lookup("db-user"))
-	_ = viper.BindPFlag("db.pass", pflag.Lookup("db-pass"))
-	_ = viper.BindPFlag("db.host", pflag.Lookup("db-host"))
-	_ = viper.BindPFlag("db.name", pflag.Lookup("db-name"))
-	_ = viper.BindPFlag("db.port", pflag.Lookup("db-port"))
-	_ = viper.BindPFlag("db.verbose", pflag.Lookup("db-verbose"))
-	_ = viper.BindPFlag("traq.cookie", pflag.Lookup("traq-cookie"))
-	_ = viper.BindPFlag("traq.apiEndpoint", pflag.Lookup("traq-api-endpoint"))
-	_ = viper.BindPFlag("knoq.cookie", pflag.Lookup("knoq-cookie"))
-	_ = viper.BindPFlag("knoq.apiEndpoint", pflag.Lookup("knoq-api-endpoint"))
-	_ = viper.BindPFlag("portal.cookie", pflag.Lookup("portal-cookie"))
-	_ = viper.BindPFlag("portal.apiEndpoint", pflag.Lookup("portal-api-endpoint"))
-
 	_ = viper.BindPFlags(pflag.CommandLine)
 
 	configPath, err := pflag.CommandLine.GetString("config")

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	config Config
-	parsed atomic.Bool
+	config   Config
+	isParsed atomic.Bool
 )
 
 type (
@@ -58,7 +58,7 @@ type (
 )
 
 func init() {
-	parsed.Store(false)
+	isParsed.Store(false)
 
 	pflag.Bool("production", false, "whether production or development")
 	pflag.Int("port", 1323, "api port")
@@ -127,13 +127,13 @@ func ReadFromFile() error {
 		return fmt.Errorf("unmarshal config: %w", err)
 	}
 
-	parsed.Store(true)
+	isParsed.Store(true)
 
 	return nil
 }
 
 func Load(editFuncs ...EditFunc) *Config {
-	if !parsed.Load() {
+	if !isParsed.Load() {
 		panic("config does not parsed")
 	}
 

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -132,16 +132,16 @@ func ReadFromFile() error {
 	return nil
 }
 
-func GetConfig() *Config {
+func Load(editFuncs ...EditFunc) *Config {
 	if !parsed.Load() {
 		panic("config does not parsed")
 	}
-	return &config
-}
 
-func GetModified(editFunc EditFunc) *Config {
 	cloned := config.clone()
-	editFunc(cloned)
+	for _, f := range editFuncs {
+		f(cloned)
+	}
+
 	return cloned
 }
 

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -103,8 +103,9 @@ func ReadFromFile() error {
 	if len(configPath) > 0 {
 		viper.SetConfigFile(configPath)
 	} else {
-		viper.SetConfigName("config") // name of config file (without extension)
-		viper.SetConfigType("yaml")   // REQUIRED if the config file does not have the extension in the name
+		// default path is ./config.yaml
+		viper.SetConfigName("config")
+		viper.SetConfigType("yaml")
 		viper.AddConfigPath(".")
 	}
 

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -1,13 +1,12 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"sync/atomic"
 	"time"
-
-	goflag "flag"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -78,7 +77,7 @@ func init() {
 	pflag.String("portal-cookie", "", "portal cookie")
 	pflag.String("portal-api-endpoint", "", "portal api endpoint")
 	pflag.StringP("config", "c", "", "config file path")
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
 func Parse() error {

--- a/util/config/config_test.go
+++ b/util/config/config_test.go
@@ -38,5 +38,5 @@ func TestParse(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, &expected, GetConfig())
+	assert.Equal(t, &expected, Load())
 }

--- a/util/config/config_test.go
+++ b/util/config/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParse(t *testing.T) {
 	viper.AddConfigPath("./testdata")
-	Parse()
+	assert.NoError(t, Parse())
 
 	expected := Config{
 		IsProduction:   true,


### PR DESCRIPTION
- :fire: remove BindPFlag (default delimiter is ".")
- :recycle: describe const directly
- :recycle: error handling
- :recycle: use atomic.Bool to parsed flag
- :adhesive_bandage: assert error
- :recycle: improve comment
- :recycle: return clone of config
- :recycle: rename to isParsed
- :recycle: rename to flag
- :fire: remove simple method
