### PR TITLE
tblsのjobが終わらない修正(pflagが指定できないことの修正)

### DIFF
--- a/util/config/config.go
+++ b/util/config/config.go
@@ -90,9 +90,25 @@ func Parse() error {
 }
 
 func ReadFromFile() error {
-	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		return fmt.Errorf("bind pflags: %w", err)
-	}
+	_ = viper.BindPFlag("production", pflag.Lookup("isProduction"))
+	_ = viper.BindPFlag("port", pflag.Lookup("port"))
+	_ = viper.BindPFlag("onlyMigrate", pflag.Lookup("only-migrate"))
+	_ = viper.BindPFlag("insertMockData", pflag.Lookup("insert-mock-data"))
+
+	_ = viper.BindPFlag("db.user", pflag.Lookup("db-user"))
+	_ = viper.BindPFlag("db.pass", pflag.Lookup("db-pass"))
+	_ = viper.BindPFlag("db.host", pflag.Lookup("db-host"))
+	_ = viper.BindPFlag("db.name", pflag.Lookup("db-name"))
+	_ = viper.BindPFlag("db.port", pflag.Lookup("db-port"))
+	_ = viper.BindPFlag("db.verbose", pflag.Lookup("db-verbose"))
+	_ = viper.BindPFlag("traq.cookie", pflag.Lookup("traq-cookie"))
+	_ = viper.BindPFlag("traq.apiEndpoint", pflag.Lookup("traq-api-endpoint"))
+	_ = viper.BindPFlag("knoq.cookie", pflag.Lookup("knoq-cookie"))
+	_ = viper.BindPFlag("knoq.apiEndpoint", pflag.Lookup("knoq-api-endpoint"))
+	_ = viper.BindPFlag("portal.cookie", pflag.Lookup("portal-cookie"))
+	_ = viper.BindPFlag("portal.apiEndpoint", pflag.Lookup("portal-api-endpoint"))
+
+	_ = viper.BindPFlags(pflag.CommandLine)
 
 	configPath, err := pflag.CommandLine.GetString("config")
 	if err != nil {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -17,6 +17,25 @@ import (
 var (
 	config   Config
 	isParsed atomic.Bool
+
+	flagKeys = []struct{ path, flag string }{
+		{"production", "production"},
+		{"port", "port"},
+		{"onlyMigrate", "only-migrate"},
+		{"insertMockData", "insert-mock-data"},
+		{"db.user", "db-user"},
+		{"db.pass", "db-pass"},
+		{"db.host", "db-host"},
+		{"db.name", "db-name"},
+		{"db.port", "db-port"},
+		{"db.verbose", "db-verbose"},
+		{"traq.cookie", "traq-cookie"},
+		{"traq.apiEndpoint", "traq-api-endpoint"},
+		{"knoq.cookie", "knoq-cookie"},
+		{"knoq.apiEndpoint", "knoq-api-endpoint"},
+		{"portal.cookie", "portal-cookie"},
+		{"portal.apiEndpoint", "portal-api-endpoint"},
+	}
 )
 
 type (
@@ -90,25 +109,15 @@ func Parse() error {
 }
 
 func ReadFromFile() error {
-	_ = viper.BindPFlag("production", pflag.Lookup("isProduction"))
-	_ = viper.BindPFlag("port", pflag.Lookup("port"))
-	_ = viper.BindPFlag("onlyMigrate", pflag.Lookup("only-migrate"))
-	_ = viper.BindPFlag("insertMockData", pflag.Lookup("insert-mock-data"))
+	for _, key := range flagKeys {
+		if err := viper.BindPFlag(key.path, pflag.Lookup(key.flag)); err != nil {
+			return fmt.Errorf("bind flag %s: %w", key.flag, err)
+		}
+	}
 
-	_ = viper.BindPFlag("db.user", pflag.Lookup("db-user"))
-	_ = viper.BindPFlag("db.pass", pflag.Lookup("db-pass"))
-	_ = viper.BindPFlag("db.host", pflag.Lookup("db-host"))
-	_ = viper.BindPFlag("db.name", pflag.Lookup("db-name"))
-	_ = viper.BindPFlag("db.port", pflag.Lookup("db-port"))
-	_ = viper.BindPFlag("db.verbose", pflag.Lookup("db-verbose"))
-	_ = viper.BindPFlag("traq.cookie", pflag.Lookup("traq-cookie"))
-	_ = viper.BindPFlag("traq.apiEndpoint", pflag.Lookup("traq-api-endpoint"))
-	_ = viper.BindPFlag("knoq.cookie", pflag.Lookup("knoq-cookie"))
-	_ = viper.BindPFlag("knoq.apiEndpoint", pflag.Lookup("knoq-api-endpoint"))
-	_ = viper.BindPFlag("portal.cookie", pflag.Lookup("portal-cookie"))
-	_ = viper.BindPFlag("portal.apiEndpoint", pflag.Lookup("portal-api-endpoint"))
-
-	_ = viper.BindPFlags(pflag.CommandLine)
+	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+		return fmt.Errorf("bind flags: %w", err)
+	}
 
 	configPath, err := pflag.CommandLine.GetString("config")
 	if err != nil {


### PR DESCRIPTION
- Revert ":fire: remove BindPFlag (default delimiter is ".")"
- :recycle: bint pflags with for
