### PR TITLE
upgrade/docker 202306

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3
+FROM golang:1.20.4
 
 RUN apt update -y
 RUN apt upgrade -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go build -o /traPortfolio .
 ##
 ## Deployment stage
 ##
-FROM alpine:3.17.3 AS deploy
+FROM alpine:3.18.0 AS deploy
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ##
 ## Build stage
 ##
-FROM golang:1.20.3-alpine AS build
+FROM golang:1.20.4-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
- build(deps): bump golang from 1.20.3-alpine to 1.20.4-alpine
- build(deps): bump golang from 1.20.3 to 1.20.4 in /.devcontainer
- build(deps): bump alpine from 3.17.3 to 3.18.0
