### PR TITLE
docker-compose.ymlにあるsqlのhealthcheckを改善した

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: mysqladmin ping -h localhost -u root -ppassword
+      test: mysql --user=root --password=password --execute "SHOW DATABASES;"
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     image: mariadb:10.6.4
     restart: always
     environment:
-      MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: portfolio
     # conohaのDBのデフォルトCharsetはutf8
@@ -24,7 +23,7 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: mysql --user=$$MYSQL_USER --password=$$MYSQL_ROOT_PASSWORD --execute "SHOW DATABASES;"
+      test: mysql --user=root --password=$$MYSQL_ROOT_PASSWORD --execute "SHOW DATABASES;"
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: mariadb:10.6.4
     restart: always
     environment:
+      MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: portfolio
     # conohaのDBのデフォルトCharsetはutf8
@@ -23,7 +24,7 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: mysql --user=root --password=password --execute "SHOW DATABASES;"
+      test: mysql --user=$$MYSQL_USER --password=$$MYSQL_ROOT_PASSWORD --execute "SHOW DATABASES;"
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
resolves #514
手元でやったらtraportfolio-backend-1がfailしてなかったのでこれで何とかなってると思います