### PR TITLE
config packageの冗長なメソッドを削除

### DIFF
--- a/infrastructure/external/apiclient.go
+++ b/infrastructure/external/apiclient.go
@@ -11,10 +11,10 @@ import (
 
 type apiClient struct {
 	client *http.Client
-	conf   *config.APIConfig
+	conf   config.APIConfig
 }
 
-func newAPIClient(jar *cookiejar.Jar, conf *config.APIConfig) apiClient {
+func newAPIClient(jar *cookiejar.Jar, conf config.APIConfig) apiClient {
 	return apiClient{
 		client: &http.Client{Jar: jar},
 		conf:   conf,
@@ -30,7 +30,7 @@ func (c *apiClient) apiGet(path string) (*http.Response, error) {
 	return c.client.Do(req)
 }
 
-func newCookieJar(c *config.APIConfig, name string) (*cookiejar.Jar, error) {
+func newCookieJar(c config.APIConfig, name string) (*cookiejar.Jar, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, err

--- a/infrastructure/external/knoq.go
+++ b/infrastructure/external/knoq.go
@@ -38,12 +38,13 @@ type knoqAPI struct {
 }
 
 func NewKnoqAPI(conf config.KnoqConfig) (KnoqAPI, error) {
-	jar, err := newCookieJar(conf.API(), "session")
+	apiConfig := (config.APIConfig)(conf)
+	jar, err := newCookieJar(apiConfig, "session")
 	if err != nil {
 		return nil, err
 	}
 
-	return &knoqAPI{newAPIClient(jar, conf.API())}, nil
+	return &knoqAPI{newAPIClient(jar, apiConfig)}, nil
 }
 
 func (a *knoqAPI) GetEvents() ([]*EventResponse, error) {

--- a/infrastructure/external/knoq.go
+++ b/infrastructure/external/knoq.go
@@ -37,7 +37,7 @@ type knoqAPI struct {
 	apiClient
 }
 
-func NewKnoqAPI(conf *config.KnoqConfig) (KnoqAPI, error) {
+func NewKnoqAPI(conf config.KnoqConfig) (KnoqAPI, error) {
 	jar, err := newCookieJar(conf.API(), "session")
 	if err != nil {
 		return nil, err

--- a/infrastructure/external/portal.go
+++ b/infrastructure/external/portal.go
@@ -33,13 +33,14 @@ type portalAPI struct {
 }
 
 func NewPortalAPI(conf config.PortalConfig) (PortalAPI, error) {
-	jar, err := newCookieJar(conf.API(), "access_token")
+	apiConfig := (config.APIConfig)(conf)
+	jar, err := newCookieJar(apiConfig, "access_token")
 	if err != nil {
 		return nil, err
 	}
 
 	return &portalAPI{
-		apiClient: newAPIClient(jar, conf.API()),
+		apiClient: newAPIClient(jar, apiConfig),
 		cache:     cache.New(1*time.Hour, 2*time.Hour),
 	}, nil
 }

--- a/infrastructure/external/portal.go
+++ b/infrastructure/external/portal.go
@@ -32,7 +32,7 @@ type portalAPI struct {
 	cache *cache.Cache
 }
 
-func NewPortalAPI(conf *config.PortalConfig) (PortalAPI, error) {
+func NewPortalAPI(conf config.PortalConfig) (PortalAPI, error) {
 	jar, err := newCookieJar(conf.API(), "access_token")
 	if err != nil {
 		return nil, err

--- a/infrastructure/external/traq.go
+++ b/infrastructure/external/traq.go
@@ -31,7 +31,7 @@ type traQAPI struct {
 	apiClient
 }
 
-func NewTraQAPI(conf *config.TraqConfig) (TraQAPI, error) {
+func NewTraQAPI(conf config.TraqConfig) (TraQAPI, error) {
 	jar, err := newCookieJar(conf.API(), "r_session")
 	if err != nil {
 		return nil, err

--- a/infrastructure/external/traq.go
+++ b/infrastructure/external/traq.go
@@ -32,12 +32,13 @@ type traQAPI struct {
 }
 
 func NewTraQAPI(conf config.TraqConfig) (TraQAPI, error) {
-	jar, err := newCookieJar(conf.API(), "r_session")
+	apiConfig := (config.APIConfig)(conf)
+	jar, err := newCookieJar(apiConfig, "r_session")
 	if err != nil {
 		return nil, err
 	}
 
-	return &traQAPI{newAPIClient(jar, conf.API())}, nil
+	return &traQAPI{newAPIClient(jar, apiConfig)}, nil
 }
 
 func (a *traQAPI) GetUsers(args *TraQGetAllArgs) ([]*TraQUserResponse, error) {

--- a/infrastructure/injector.go
+++ b/infrastructure/injector.go
@@ -21,7 +21,7 @@ func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 	if c.IsProduction {
 		var err error
 
-		portalAPI, err = external.NewPortalAPI(c.PortalConf())
+		portalAPI, err = external.NewPortalAPI(c.Portal)
 		if err != nil {
 			return handler.API{}, err
 		}

--- a/infrastructure/injector.go
+++ b/infrastructure/injector.go
@@ -26,7 +26,7 @@ func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 			return handler.API{}, err
 		}
 
-		traQAPI, err = external.NewTraQAPI(c.TraqConf())
+		traQAPI, err = external.NewTraQAPI(c.Traq)
 		if err != nil {
 			return handler.API{}, err
 		}

--- a/infrastructure/injector.go
+++ b/infrastructure/injector.go
@@ -31,7 +31,7 @@ func InjectAPIServer(c *config.Config, db *gorm.DB) (handler.API, error) {
 			return handler.API{}, err
 		}
 
-		knoqAPI, err = external.NewKnoqAPI(c.KnoqConf())
+		knoqAPI, err = external.NewKnoqAPI(c.Knoq)
 		if err != nil {
 			return handler.API{}, err
 		}

--- a/infrastructure/repository/db.go
+++ b/infrastructure/repository/db.go
@@ -42,7 +42,7 @@ func (d dialector) Translate(err error) error {
 	return err
 }
 
-func NewGormDB(conf *config.SQLConfig) (*gorm.DB, error) {
+func NewGormDB(conf config.SQLConfig) (*gorm.DB, error) {
 	d := dialector{mysql.New(mysql.Config{DSNConfig: conf.DsnConfig()})}
 	engine, err := gorm.Open(d, conf.GormConfig())
 	if err != nil {

--- a/integration_tests/handler/main_test.go
+++ b/integration_tests/handler/main_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 
 	// disable mysql driver logging
 	_ = mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", 0)))
-	_db, closeFunc, err := testutils.RunMySQLContainerOnDocker(c.SQLConf())
+	_db, closeFunc, err := testutils.RunMySQLContainerOnDocker(c.DB)
 	if err != nil {
 		panic(err)
 	}

--- a/integration_tests/repository/main_test.go
+++ b/integration_tests/repository/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 
 	// disable mysql driver logging
 	_ = mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", 0)))
-	_db, closeFunc, err := testutils.RunMySQLContainerOnDocker(c.SQLConf())
+	_db, closeFunc, err := testutils.RunMySQLContainerOnDocker(c.DB)
 	if err != nil {
 		panic(err)
 	}

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -40,7 +40,7 @@ func establishTestDBConnection(t *testing.T) *gorm.DB {
 	sqlConf := config.Load(func(c *config.Config) {
 		c.DB.Name = "portfolio_test_" + t.Name()
 		c.DB.Port = Port
-	}).SQLConf()
+	}).DB
 
 	_, err := DB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", sqlConf.Name))
 	assert.NoError(t, err)
@@ -61,7 +61,7 @@ func dropAll(t *testing.T, db *gorm.DB) {
 	assert.NoError(t, err)
 }
 
-func RunMySQLContainerOnDocker(sqlConf *config.SQLConfig) (*sql.DB, func() error, error) {
+func RunMySQLContainerOnDocker(sqlConf config.SQLConfig) (*sql.DB, func() error, error) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		return nil, nil, fmt.Errorf("create docker pool: %w", err)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/labstack/echo/v4"
@@ -48,5 +49,5 @@ func main() {
 	}
 
 	// Start server
-	e.Logger.Fatal(e.Start(appConf.Addr()))
+	e.Logger.Fatal(e.Start(fmt.Sprintf(":%d", appConf.Port)))
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 
 	appConf := config.Load()
-	db, err := repository.NewGormDB(appConf.SQLConf())
+	db, err := repository.NewGormDB(appConf.DB)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -200,10 +200,6 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
 }
 
-func (c *Config) KnoqConf() *KnoqConfig {
-	return &c.Knoq
-}
-
 func (c *Config) PortalConf() *PortalConfig {
 	return &c.Portal
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -200,10 +200,6 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
 }
 
-func (c *Config) TraqConf() *TraqConfig {
-	return &c.Traq
-}
-
 func (c *Config) KnoqConf() *KnoqConfig {
 	return &c.Knoq
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -200,18 +200,6 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
 }
 
-func (c *TraqConfig) API() *APIConfig {
-	return (*APIConfig)(c)
-}
-
-func (c *KnoqConfig) API() *APIConfig {
-	return (*APIConfig)(c)
-}
-
-func (c *PortalConfig) API() *APIConfig {
-	return (*APIConfig)(c)
-}
-
 func (c *SQLConfig) DsnConfig() *mysql.Config {
 	return &mysql.Config{
 		User:                 c.User,

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -200,10 +200,6 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
 }
 
-func (c *Config) PortalConf() *PortalConfig {
-	return &c.Portal
-}
-
 func (c *TraqConfig) API() *APIConfig {
 	return (*APIConfig)(c)
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -200,10 +200,6 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)
 }
 
-func (c *Config) SQLConf() *SQLConfig {
-	return &c.DB
-}
-
 func (c *Config) TraqConf() *TraqConfig {
 	return &c.Traq
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -196,10 +196,6 @@ func (c *Config) clone() *Config {
 	return &cloned
 }
 
-func (c *Config) Addr() string {
-	return fmt.Sprintf(":%d", c.Port)
-}
-
 func (c *SQLConfig) DsnConfig() *mysql.Config {
 	return &mysql.Config{
 		User:                 c.User,

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -216,12 +216,6 @@ func (c *SQLConfig) DsnConfig() *mysql.Config {
 	}
 }
 
-func (c *SQLConfig) DsnConfigWithoutName() *mysql.Config {
-	cfg := c.DsnConfig()
-	cfg.DBName = ""
-	return cfg
-}
-
 func (c *SQLConfig) GormConfig() *gorm.Config {
 	var (
 		logLevel  = logger.Warn


### PR DESCRIPTION
- :fire: remove (*Config).SQLConf()
- :fire: remove (*Config).TraqConf()
- :fire: remove (*Config).KnoqConf()
- :fire: remove (*Config).PortalConf()
- :fire: remove (*Traq/Knoq/PortalConfig).API()
- :fire: remove (*SQLConfig).DsnConfigWithoutName()
- :fire: remove (*Config).Addr()
