### PR TITLE
refactor/config

### DIFF
--- a/infrastructure/external/knoq.go
+++ b/infrastructure/external/knoq.go
@@ -37,14 +37,13 @@ type knoqAPI struct {
 	apiClient
 }
 
-func NewKnoqAPI(conf config.KnoqConfig) (KnoqAPI, error) {
-	apiConfig := (config.APIConfig)(conf)
-	jar, err := newCookieJar(apiConfig, "session")
+func NewKnoqAPI(conf config.APIConfig) (KnoqAPI, error) {
+	jar, err := newCookieJar(conf, "session")
 	if err != nil {
 		return nil, err
 	}
 
-	return &knoqAPI{newAPIClient(jar, apiConfig)}, nil
+	return &knoqAPI{newAPIClient(jar, conf)}, nil
 }
 
 func (a *knoqAPI) GetEvents() ([]*EventResponse, error) {

--- a/infrastructure/external/portal.go
+++ b/infrastructure/external/portal.go
@@ -32,15 +32,14 @@ type portalAPI struct {
 	cache *cache.Cache
 }
 
-func NewPortalAPI(conf config.PortalConfig) (PortalAPI, error) {
-	apiConfig := (config.APIConfig)(conf)
-	jar, err := newCookieJar(apiConfig, "access_token")
+func NewPortalAPI(conf config.APIConfig) (PortalAPI, error) {
+	jar, err := newCookieJar(conf, "access_token")
 	if err != nil {
 		return nil, err
 	}
 
 	return &portalAPI{
-		apiClient: newAPIClient(jar, apiConfig),
+		apiClient: newAPIClient(jar, conf),
 		cache:     cache.New(1*time.Hour, 2*time.Hour),
 	}, nil
 }

--- a/infrastructure/external/traq.go
+++ b/infrastructure/external/traq.go
@@ -31,14 +31,13 @@ type traQAPI struct {
 	apiClient
 }
 
-func NewTraQAPI(conf config.TraqConfig) (TraQAPI, error) {
-	apiConfig := (config.APIConfig)(conf)
-	jar, err := newCookieJar(apiConfig, "r_session")
+func NewTraQAPI(conf config.APIConfig) (TraQAPI, error) {
+	jar, err := newCookieJar(conf, "r_session")
 	if err != nil {
 		return nil, err
 	}
 
-	return &traQAPI{newAPIClient(jar, apiConfig)}, nil
+	return &traQAPI{newAPIClient(jar, conf)}, nil
 }
 
 func (a *traQAPI) GetUsers(args *TraQGetAllArgs) ([]*TraQUserResponse, error) {

--- a/integration_tests/testutils/db.go
+++ b/integration_tests/testutils/db.go
@@ -37,10 +37,9 @@ func SetupGormDB(t *testing.T) *gorm.DB {
 func establishTestDBConnection(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	sqlConf := config.Load(func(c *config.Config) {
-		c.DB.Name = "portfolio_test_" + t.Name()
-		c.DB.Port = Port
-	}).DB
+	sqlConf := config.Load().DB
+	sqlConf.Name = "portfolio_test_" + t.Name()
+	sqlConf.Port = Port
 
 	_, err := DB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", sqlConf.Name))
 	assert.NoError(t, err)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -41,26 +41,25 @@ var (
 )
 
 type (
-	// Immutable except within this package or EditFunc
 	Config struct {
 		IsProduction   bool `mapstructure:"production"`
-		Port           int  `mapstructure:"port"`
-		OnlyMigrate    bool `mapstructure:"onlyMigrate"`
-		InsertMockData bool `mapstructure:"insertMockData"`
+		Port           int
+		OnlyMigrate    bool
+		InsertMockData bool
 
-		DB     SQLConfig    `mapstructure:"db"`
-		Traq   TraqConfig   `mapstructure:"traq"`
-		Knoq   KnoqConfig   `mapstructure:"knoq"`
-		Portal PortalConfig `mapstructure:"portal"`
+		DB     SQLConfig
+		Traq   TraqConfig
+		Knoq   KnoqConfig
+		Portal PortalConfig
 	}
 
 	SQLConfig struct {
-		User    string `mapstructure:"user"`
-		Pass    string `mapstructure:"pass"`
-		Host    string `mapstructure:"host"`
-		Name    string `mapstructure:"name"`
-		Port    int    `mapstructure:"port"`
-		Verbose bool   `mapstructure:"verbose"`
+		User    string
+		Pass    string
+		Host    string
+		Name    string
+		Port    int
+		Verbose bool
 	}
 
 	// NOTE: wireが複数の同じ型の変数を扱えないためdefined typeを用いる
@@ -70,8 +69,8 @@ type (
 	PortalConfig APIConfig
 
 	APIConfig struct {
-		Cookie      string `mapstructure:"cookie"`
-		APIEndpoint string `mapstructure:"apiEndpoint"`
+		Cookie      string
+		APIEndpoint string
 	}
 
 	EditFunc func(*Config)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -112,11 +112,7 @@ func ReadFromFile() error {
 		return fmt.Errorf("bind flags: %w", err)
 	}
 
-	configPath, err := pflag.CommandLine.GetString("config")
-	if err != nil {
-		return fmt.Errorf("get config flag: %w", err)
-	}
-
+	configPath := viper.GetString("config")
 	if len(configPath) > 0 {
 		viper.SetConfigFile(configPath)
 	} else {
@@ -132,7 +128,7 @@ func ReadFromFile() error {
 				return fmt.Errorf("read config from %s: %w", configPath, err)
 			}
 
-			log.Printf("config file does not found: %v", err)
+			log.Printf("config file does not found: %v\n", err)
 		} else {
 			return fmt.Errorf("read config: %w", err)
 		}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -66,8 +66,6 @@ type (
 		Cookie      string
 		APIEndpoint string
 	}
-
-	EditFunc func(*Config)
 )
 
 func init() {
@@ -171,17 +169,12 @@ func ReadDefault() error {
 	return nil
 }
 
-func Load(editFuncs ...EditFunc) *Config {
+func Load() *Config {
 	if !isParsed.Load() {
 		panic("config does not parsed")
 	}
 
-	cloned := config.clone()
-	for _, f := range editFuncs {
-		f(cloned)
-	}
-
-	return cloned
+	return config.clone()
 }
 
 func (c *Config) clone() *Config {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -48,9 +48,9 @@ type (
 		InsertMockData bool
 
 		DB     SQLConfig
-		Traq   TraqConfig
-		Knoq   KnoqConfig
-		Portal PortalConfig
+		Traq   APIConfig
+		Knoq   APIConfig
+		Portal APIConfig
 	}
 
 	SQLConfig struct {
@@ -61,12 +61,6 @@ type (
 		Port    int
 		Verbose bool
 	}
-
-	// NOTE: wireが複数の同じ型の変数を扱えないためdefined typeを用いる
-	// Ref: https://github.com/google/wire/blob/d07cde0df9/docs/faq.md#what-if-my-dependency-graph-has-two-dependencies-of-the-same-type
-	TraqConfig   APIConfig
-	KnoqConfig   APIConfig
-	PortalConfig APIConfig
 
 	APIConfig struct {
 		Cookie      string

--- a/util/config/config_test.go
+++ b/util/config/config_test.go
@@ -24,15 +24,15 @@ func TestParse(t *testing.T) {
 			Port:    3001,
 			Verbose: true,
 		},
-		Traq: TraqConfig{
+		Traq: APIConfig{
 			Cookie:      "traq cookie",
 			APIEndpoint: "traq endpoint",
 		},
-		Knoq: KnoqConfig{
+		Knoq: APIConfig{
 			Cookie:      "knoq cookie",
 			APIEndpoint: "knoq endpoint",
 		},
-		Portal: PortalConfig{
+		Portal: APIConfig{
 			Cookie:      "portal cookie",
 			APIEndpoint: "portal endpoint",
 		},


### PR DESCRIPTION
- :fire: remove redundant mapstructure tag
- :fire: remove defined types from APIConfig
- :fire: remove EditFunc
- :recycle: use viper.GetString("config")
