### PR TITLE
:wrench: Use CODECOV_TOKEN to upload

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,11 +88,13 @@ jobs:
         with:
           files: ./coverage_unit.txt
           flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage data (Integration)
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage_integration.txt
           flags: integration
+          token: ${{ secrets.CODECOV_TOKEN }}
   tbls:
     name: TBLS
     runs-on: ubuntu-latest


### PR DESCRIPTION
実は[codecov/codecov-action@v4](https://github.com/codecov/codecov-action/releases/tag/v4.0.0)からカバレッジのアップロードにTokenが必要になっていました

> Tokenless uploading is unsupported.

その対応です、H1ronoからはRepository secretsをいじれないので`CODECOV_TOKEN`を追加してからマージしてください