### PR TITLE
凍結済みユーザーの表示を行わない

### DIFF
--- a/infrastructure/repository/user_test.go
+++ b/infrastructure/repository/user_test.go
@@ -52,33 +52,6 @@ func TestUserRepository_GetUsers(t *testing.T) {
 			assertion: assert.NoError,
 		},
 		{
-			name: "All IncludeSuspended",
-			args: args{args: &urepository.GetUsersArgs{
-				IncludeSuspended: optional.From(true),
-			}},
-			expected: []*domain.User{
-				domain.NewUser(
-					mockdata.MockUsers[0].ID,
-					mockdata.MockUsers[0].Name,
-					mockdata.MockPortalUsers[0].RealName,
-					mockdata.MockUsers[0].Check,
-				),
-				domain.NewUser(
-					mockdata.MockUsers[1].ID,
-					mockdata.MockUsers[1].Name,
-					mockdata.MockPortalUsers[1].RealName,
-					mockdata.MockUsers[1].Check,
-				),
-				domain.NewUser(
-					mockdata.MockUsers[2].ID,
-					mockdata.MockUsers[2].Name,
-					mockdata.MockPortalUsers[2].RealName,
-					mockdata.MockUsers[2].Check,
-				),
-			},
-			assertion: assert.NoError,
-		},
-		{
 			name: "Name",
 			args: args{args: &urepository.GetUsersArgs{
 				Name: optional.From(mockdata.MockTraQUsers[0].Name),
@@ -92,15 +65,6 @@ func TestUserRepository_GetUsers(t *testing.T) {
 				),
 			},
 			assertion: assert.NoError,
-		},
-		{
-			name: "Invalid arg",
-			args: args{args: &urepository.GetUsersArgs{
-				Name:             optional.From(mockdata.MockTraQUsers[0].Name),
-				IncludeSuspended: optional.From(true),
-			}},
-			expected:  nil,
-			assertion: assert.Error,
 		},
 	}
 

--- a/interfaces/handler/user.go
+++ b/interfaces/handler/user.go
@@ -30,9 +30,8 @@ func (h *UserHandler) GetUsers(c echo.Context) error {
 
 	ctx := c.Request().Context()
 	args := repository.GetUsersArgs{
-		IncludeSuspended: optional.FromPtr((*bool)(req.IncludeSuspended)),
-		Name:             optional.FromPtr((*string)(req.Name)),
-		Limit:            optional.FromPtr((*int)(req.Limit)),
+		Name:  optional.FromPtr((*string)(req.Name)),
+		Limit: optional.FromPtr((*int)(req.Limit)),
 	}
 
 	users, err := h.user.GetUsers(ctx, &args)

--- a/interfaces/handler/user_test.go
+++ b/interfaces/handler/user_test.go
@@ -65,35 +65,6 @@ func TestUserHandler_GetUsers(t *testing.T) {
 			statusCode: http.StatusOK,
 		},
 		{
-			name: "Success_WithOpts_IncludeSuspended",
-			setup: func(mr MockRepository) (hres []*schema.User, path string) {
-				casenum := 2
-				repoUsers := []*domain.User{}
-				hresUsers := []*schema.User{}
-
-				for range casenum {
-					ruser := domain.NewUser(random.UUID(), random.AlphaNumeric(), random.AlphaNumeric(), random.Bool())
-					huser := schema.User{
-						Id:       ruser.ID,
-						Name:     ruser.Name,
-						RealName: ruser.RealName(),
-					}
-
-					repoUsers = append(repoUsers, ruser)
-					hresUsers = append(hresUsers, &huser)
-				}
-
-				includeSuspened := random.Bool()
-				args := repository.GetUsersArgs{
-					IncludeSuspended: optional.From(includeSuspened),
-				}
-
-				mr.user.EXPECT().GetUsers(anyCtx{}, &args).Return(repoUsers, nil)
-				return hresUsers, fmt.Sprintf("/api/v1/users?includeSuspended=%t", includeSuspened)
-			},
-			statusCode: http.StatusOK,
-		},
-		{
 			name: "Success_WithOpts_Name",
 			setup: func(mr MockRepository) (hres []*schema.User, path string) {
 				repoUsers := []*domain.User{

--- a/usecases/repository/user_repository.go
+++ b/usecases/repository/user_repository.go
@@ -11,7 +11,6 @@ import (
 )
 
 type GetUsersArgs struct {
-	IncludeSuspended optional.Of[bool]
 	Name             optional.Of[string]
 	Limit            optional.Of[int]
 }


### PR DESCRIPTION
https://github.com/traPtitech/traPortfolio/issues/706

他にもユーザーの表示に関するものはいくつかあるがとりあえずユーザー個人のユーザー情報が取れないようにした

IncludeSuspendedは消しました