### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,21 +22,21 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Generate Image Tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: meta
         with:
           images: ghcr.io/traptitech/${{ env.IMAGE_NAME }}
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: traptitech
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -52,7 +52,7 @@ jobs:
       - build
     steps:
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.STAGING_SSH_KEY }}
           known_hosts: ${{ secrets.STAGING_KNOWN_HOSTS }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,15 +11,15 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
       - name: Download go modules
         run: go mod download
       - name: Compile go packages
         run: go build -o traPortfolio .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: traPortfolio
           path: traPortfolio
@@ -29,11 +29,11 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: latest
           install-mode: goinstall
@@ -43,15 +43,15 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
       - name: Run tests
         run: |
           go test ./internal/... -coverprofile=coverage_unit.tmp.txt -race -vet=off
           grep -v "mock_" < coverage_unit.tmp.txt > coverage_unit.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage_unit
           path: coverage_unit.txt
@@ -61,15 +61,15 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
       - name: Run tests
         run: |
           go test ./integration_tests/... -coverpkg=./... -coverprofile=coverage_integration.tmp.txt -race -vet=off
           grep -v "mock_" < coverage_integration.tmp.txt > coverage_integration.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage_integration
           path: coverage_integration.txt
@@ -80,21 +80,21 @@ jobs:
       - test-unit
       - test-integration
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: coverage_unit
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: coverage_integration
       - name: Upload coverage data (Unit)
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ./coverage_unit.txt
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage data (Integration)
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ./coverage_integration.txt
           flags: integration
@@ -105,13 +105,13 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: traPortfolio
       - name: Setup MySQL container
         run: docker compose up -d --wait mysql
-      - uses: k1low/setup-tbls@v1
+      - uses: k1low/setup-tbls@f25e3d013a596865b2db90dac7ee19e9f15b5780 # v1.4.0
       - name: Run database linter
         run: |
           chmod +x ./traPortfolio
@@ -123,6 +123,6 @@ jobs:
     container:
       image: stoplight/spectral:6.5.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Spectral checks
         run: spectral lint ./docs/swagger/traPortfolio.v1.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ##
 ## Build stage
 ##
-FROM golang:1.25.3-alpine AS build
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS build
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 ##
 ## Deployment stage
 ##
-FROM alpine:3 AS deploy
+FROM alpine:3@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS deploy
 
 WORKDIR /
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,7 @@ services:
           path: ./
 
   mysql:
-    image: mariadb:10.6.4
+    image: mariadb:10.6.4@sha256:c014ba1efc5dbd711d0520c7762d57807f35549de3414eb31e942a420c8a2ed2
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -38,7 +38,7 @@ services:
       retries: 10
 
   adminer:
-    image: adminer:standalone
+    image: adminer:standalone@sha256:cc64d253db4f016cbcff2ff2f01e60ed07e74f38b4398f84d3c4fae4b5ce0e07
     restart: always
     environment:
       ADMINER_DEFAULT_SERVER: mysql


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

## 適用した変更

### ✅ GitHub Actions を commit SHA で固定（26 箇所）
タグ／ブランチ参照は可変で付け替えられ得るため、不変な commit SHA に固定しました（[pinact](https://github.com/suzuki-shunsuke/pinact) を使用）。`# vX` コメントを残しているので **Dependabot / Renovate は引き続き自動更新できます**。

### ✅ Docker ベースイメージを digest 固定（4 箇所）
信頼できる発行元（Docker 公式 / distroless / ghcr.io/traPtitech 等）の可変タグに `@sha256:...` を付与しました。
- `golang:1.25.3-alpine`（`Dockerfile`）
- `alpine:3`（`Dockerfile`）
- `mariadb:10.6.4`（`compose.yaml`）
- `adminer:standalone`（`compose.yaml`）

## 確認のお願い
- [ ] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。