### PR TITLE
chore: フロントエンドのDocker Compose環境の構築

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,31 @@
+{
+    admin off
+    auto_https off
+}
+
+ui.localhost:80 {
+    handle /api/v1/* {
+        reverse_proxy backend:1323
+    }
+    handle {
+        reverse_proxy ui:80
+    }
+}
+
+dashboard.localhost:80 {
+    handle /api/v1/* {
+        reverse_proxy backend:1323
+    }
+    handle {
+        reverse_proxy dashboard:80
+    }
+}
+
+localhost:80 {
+    handle /api/v1/* {
+        reverse_proxy backend:1323
+    }
+    handle {
+        reverse_proxy ui:80
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,14 @@
 services:
+  caddy:
+    image: caddy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
   backend:
     build: ./
     restart: always
@@ -34,7 +44,7 @@ services:
       - "80"
     depends_on:
       - backend
-      
+
   mysql:
     image: mariadb:10.6.4
     restart: always
@@ -61,3 +71,7 @@ services:
       ADMINER_DESIGN: pepa-linha
     ports:
       - "3001:8080"
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: caddy:latest
     restart: unless-stopped
     ports:
-      - "80:80"
+      - "3000:80"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
@@ -30,7 +30,7 @@ services:
           path: ./
 
   ui:
-    image: ghcr.io/traptitech/traportfolio-ui:preview-446-c88cec0752107bfbfe01b3d5fef5aafec8971eaf
+    image: ghcr.io/traptitech/traportfolio-ui:main
     restart: always
     expose:
       - "80"

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,14 @@ services:
         - action: rebuild
           path: ./
 
+  ui:
+    image: ghcr.io/traptitech/traportfolio-ui:preview-446-c88cec0752107bfbfe01b3d5fef5aafec8971eaf
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - backend
+
   mysql:
     image: mariadb:10.6.4
     restart: always

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,14 @@ services:
     depends_on:
       - backend
 
+  dashboard:
+    image: ghcr.io/traptitech/traportfolio-dashboard:main
+    restart: always
+    expose:
+      - "80"
+    depends_on:
+      - backend
+      
   mysql:
     image: mariadb:10.6.4
     restart: always


### PR DESCRIPTION
close #670 

- `compose.yaml`に`ui` /  `dashboard` /  `caddy` サービスを追加
- `Caddyfile` を追加し、`ui.localhost` / `dashboard.localhost` / `localhost` でリバースプロキシを設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 逆プロキシとしてCaddyを追加し、ローカルで `ui.localhost` / `dashboard.localhost` / `localhost` の3つのアクセス経路を使い分け可能に。
  * `/api/v1/*` は共通のバックエンドへ自動転送。
  * `localhost:3000` 経由のルーティングを整理し、UI表示とAPIの切り分けがより分かりやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->